### PR TITLE
Allow mounting custom volume directories

### DIFF
--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -53,7 +53,7 @@ var ContainerSettingsVolumes = React.createClass({
       volumes: volumes
     });
   },
-  removeVolume: function (dockerVol, deleteContainer) {
+  removeVolume: function (dockerVol, deleteContainer = false) {
     var containerVolumes = _.clone(this.props.container.Volumes);
     if (deleteContainer)
     {
@@ -99,7 +99,7 @@ var ContainerSettingsVolumes = React.createClass({
       from: 'settings'
     });
 
-    this.removeVolume(dockerVol, false);
+    this.removeVolume(dockerVol);
   },
   handleOpenVolumeClick: function (path) {
     metrics.track('Opened Volume Directory', {

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -125,7 +125,7 @@ var ContainerSettingsVolumes = React.createClass({
       if (!alreadyExists)
       {
         volumes[index][2] = this.state.newVolumePath;
-        volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
+        volumes[index][1] = '';
 
         volumes.push([util.randomId(), '', '']);
 

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -59,7 +59,7 @@ var ContainerSettingsVolumes = React.createClass({
     {
       delete containerVolumes[dockerVol];
     } else {
-      containerVolumes[dockerVol] = '';
+      containerVolumes[dockerVol] = null;
     }
 
     this.updateContainerBindsAndVolumes(containerVolumes);

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -2,12 +2,44 @@ var _ = require('underscore');
 var React = require('react/addons');
 var remote = require('remote');
 var dialog = remote.require('dialog');
+var ContainerUtil = require('../utils/ContainerUtil');
 var shell = require('shell');
 var util = require('../utils/Util');
 var metrics = require('../utils/MetricsUtil');
 var containerActions = require('../actions/ContainerActions');
 
 var ContainerSettingsVolumes = React.createClass({
+
+  getInitialState: function () {
+    // Build an Array from the container 'Volumes' attribute
+    let volumes = ContainerUtil.volumes(this.props.container) || [];
+    volumes.push(['', '']);
+
+    volumes = _.map(volumes, volume => {
+      // Add a random ID for each lines (which will be re-used later in the
+      // docker path)
+      return [util.randomId(), volume[0], volume[1]];
+    });
+
+    return {
+      // Save a copy of the volumes for the 'Reset' button
+      originalVolumes: _.clone(volumes),
+      // Mutable volumes used to build the view and add/remove containers
+      volumes: volumes,
+      // Store the new container path
+      newVolumePath: null
+    }
+  },
+
+  // Update the container Binds and Volumes from the `volumes` variable
+  updateContainerBindsAndVolumes: function (volumes) {
+    var binds = [];
+    _.pairs(volumes).map(function (pair) {
+      if (pair[1]) { binds.push(pair[1] + ':' + pair[0]) }
+    });
+    containerActions.update(this.props.container.Name, {Binds: binds, Volumes: volumes});
+  },
+
   handleChooseVolumeClick: function (dockerVol) {
     dialog.showOpenDialog({properties: ['openDirectory', 'createDirectory']}, (filenames) => {
       if (!filenames) {
@@ -29,13 +61,11 @@ var ContainerSettingsVolumes = React.createClass({
       if(util.isWindows()) {
         directory = util.escapePath(util.windowsToLinuxPath(directory));
       }
+
       var volumes = _.clone(this.props.container.Volumes);
       volumes[dockerVol] = directory;
-      var binds = _.pairs(volumes).map(function (pair) {
-        return pair[1] + ':' + pair[0];
-      });
 
-      containerActions.update(this.props.container.Name, {Binds: binds, Volumes: volumes});
+      this.updateContainerBindsAndVolumes(volumes);
     });
   },
   handleRemoveVolumeClick: function (dockerVol) {
@@ -43,15 +73,10 @@ var ContainerSettingsVolumes = React.createClass({
       from: 'settings'
     });
 
-    var hostConfig = _.clone(this.props.container.HostConfig);
-    var binds = hostConfig.Binds;
     var volumes = _.clone(this.props.container.Volumes);
     volumes[dockerVol] = null;
-    var index = _.findIndex(binds, bind => bind.indexOf(`:${dockerVol}`) !== -1);
-    if (index >= 0) {
-      binds.splice(index, 1);
-    }
-    containerActions.update(this.props.container.Name, {HostConfig: hostConfig, Binds: binds, Volumes: volumes});
+
+    this.updateContainerBindsAndVolumes(volumes);
   },
   handleOpenVolumeClick: function (path) {
     metrics.track('Opened Volume Directory', {
@@ -63,13 +88,67 @@ var ContainerSettingsVolumes = React.createClass({
       shell.showItemInFolder(path);
     }
   },
+  // Store temporarily the typed path for the new volume
+  handleChangeNewVolumePath: function(index, event) {
+    this.setState({
+      newVolumePath: event.target.value
+    });
+  },
+  // Add the new volume in the `volumes` and add a new line for the next new
+  // volume
+  handleAddVolume: function (index) {
+    let volumes = _.map(this.state.volumes, _.clone);
+    volumes[index][2] = this.state.newVolumePath;
+    volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
+    volumes.push([util.randomId(), '', '']);
+    this.setState({
+      volumes: volumes
+    });
+    metrics.track('Added Pending Volume');
+  },
+  // Remove the clicked volume from the `volume` variable
+  handleRemoveVolume: function(index) {
+    let volumes = _.map(this.state.volumes, _.clone);
+    volumes.splice(index, 1);
+
+    if (volumes.length === 0) {
+      volumes.push([util.randomId(), '', '']);
+    }
+
+    this.setState({
+      volumes: volumes
+    });
+
+    metrics.track('Removed Volume');
+  },
+  // Save all the volumes from the `volumes` variable in the container 'Volumes'
+  // attribute
+  handleSaveVolumes: function () {
+    metrics.track('Saved Volumes');
+    var volumes = {};
+    _.map(this.state.volumes, (kvp, index) => {
+      let [id, val, key] = kvp;
+      if (key !== '') { volumes[key] = val; }
+    });
+
+    this.updateContainerBindsAndVolumes(volumes);
+  },
+  // Replace the `volumes` variable by a copy of `originalVolumes` where are
+  // stored the original volumes
+  handleResetVolumes: function() {
+    let volumes = _.clone(this.state.originalVolumes);
+    this.setState({
+      volumes: volumes
+    });
+  },
   render: function () {
     if (!this.props.container) {
       return false;
     }
 
     var homeDir = util.isWindows() ? util.windowsToLinuxPath(util.home()) : util.home();
-    var volumes = _.map(this.props.container.Volumes, (val, key) => {
+    var volumes = _.map(this.state.volumes, (kvp, index) => {
+      let [id, val, key] = kvp;
       if (!val || val.indexOf(homeDir) === -1) {
         val = (
           <span className="value-right">No Folder</span>
@@ -80,17 +159,41 @@ var ContainerSettingsVolumes = React.createClass({
           <a className="value-right" onClick={this.handleOpenVolumeClick.bind(this, val)}>{local.replace(process.env.HOME, '~')}</a>
         );
       }
-      return (
-        <tr>
-          <td>{key}</td>
-          <td>{val}</td>
-          <td>
+
+      let actions;
+      let icon;
+      if (index === this.state.volumes.length - 1) {
+        icon = <a onClick={this.handleAddVolume.bind(this, index)} className="only-icon btn btn-positive small"><span className="icon icon-add"></span></a>;
+      } else {
+        actions = (
+          <span>
             <a className="btn btn-action small" disabled={this.props.container.State.Updating} onClick={this.handleChooseVolumeClick.bind(this, key)}>Change</a>
             <a className="btn btn-action small" disabled={this.props.container.State.Updating} onClick={this.handleRemoveVolumeClick.bind(this, key)}>Remove</a>
+          </span>
+        );
+        icon = <a onClick={this.handleRemoveVolume.bind(this, index)} className="only-icon btn btn-action small"><span className="icon icon-delete"></span></a>;
+      }
+
+      let volumePath = key;
+      if (key === '')
+      {
+        volumePath = (
+          <input type="text" className="key line" onChange={this.handleChangeNewVolumePath.bind(this, index)}></input>
+        );
+      }
+
+      return (
+        <tr>
+          <td>{volumePath}</td>
+          <td>{val}</td>
+          <td>
+            {actions}
+            {icon}
           </td>
         </tr>
       );
     });
+
     return (
       <div className="settings-panel">
         <div className="settings-section">
@@ -107,6 +210,8 @@ var ContainerSettingsVolumes = React.createClass({
               {volumes}
             </tbody>
           </table>
+          <a className="btn btn-action" disabled={this.props.container.State.Updating} onClick={this.handleSaveVolumes}>Save</a>
+          <a className="btn btn-action" disabled={this.props.container.State.Updating} onClick={this.handleResetVolumes}>Reset</a>
         </div>
       </div>
     );

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -115,14 +115,26 @@ var ContainerSettingsVolumes = React.createClass({
     if (this.state.newVolumePath)
     {
       let volumes = _.map(this.state.volumes, _.clone);
-      volumes[index][2] = this.state.newVolumePath;
-      volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
-      volumes.push([util.randomId(), '', '']);
-      this.setState({
-        volumes: volumes,
-        newVolumePath: null
+
+      var alreadyExists = false
+      _.map(this.state.volumes, (kvp, index) => {
+        let [id, val, key] = kvp;
+        if (key === this.state.newVolumePath) { alreadyExists = true }
       });
-      metrics.track('Added Pending Volume');
+
+      if (!alreadyExists)
+      {
+        volumes[index][2] = this.state.newVolumePath;
+        volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
+
+        volumes.push([util.randomId(), '', '']);
+
+        this.setState({
+          volumes: volumes,
+          newVolumePath: null
+        });
+        metrics.track('Added Pending Volume');
+      }
     }
   },
   // Remove the clicked volume from the `volume` variable

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -112,14 +112,18 @@ var ContainerSettingsVolumes = React.createClass({
   // Add the new volume in the `volumes` and add a new line for the next new
   // volume
   handleAddVolume: function (index) {
-    let volumes = _.map(this.state.volumes, _.clone);
-    volumes[index][2] = this.state.newVolumePath;
-    volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
-    volumes.push([util.randomId(), '', '']);
-    this.setState({
-      volumes: volumes
-    });
-    metrics.track('Added Pending Volume');
+    if (this.state.newVolumePath)
+    {
+      let volumes = _.map(this.state.volumes, _.clone);
+      volumes[index][2] = this.state.newVolumePath;
+      volumes[index][1] = '/var/lib/docker/volumes/' + volumes[index][0] + '/_data';
+      volumes.push([util.randomId(), '', '']);
+      this.setState({
+        volumes: volumes,
+        newVolumePath: null
+      });
+      metrics.track('Added Pending Volume');
+    }
   },
   // Remove the clicked volume from the `volume` variable
   handleRemoveVolume: function(index) {

--- a/src/utils/ContainerUtil.js
+++ b/src/utils/ContainerUtil.js
@@ -13,6 +13,16 @@ var ContainerUtil = {
     });
   },
 
+  volumes: function (container) {
+    if (!container || !container.Volumes) {
+      return [];
+    }
+    return _.map(container.Volumes, (key, value) => {
+      var splits = [key, value];
+      return splits;
+    });
+  },
+
   // Provide Foreground options
   mode: function (container) {
     if (!container || !container.Config) {


### PR DESCRIPTION
This pull request solve the issue #376.

This pull request updates the "Volumes" sub tab panel of the "Settings" container tab with a line to add new volumes:

![screenshot from 2015-06-25 20 51 02](https://cloud.githubusercontent.com/assets/478564/8362839/7fc17e54-1b7b-11e5-95f0-0ac13841987a.png)

Writing a path, clicking the plus and then 'Save' will update the container so that a new folder is available but empty.

![screenshot from 2015-06-25 20 53 15](https://cloud.githubusercontent.com/assets/478564/8362886/cfa14224-1b7b-11e5-9c6a-3c891b44e4a9.png)

Then selecting a local folder using the 'CHANGE' button will now refresh correctly the UI (before it was refresh only when going somewhere else and then back to the tab) and also will Bind the local path to the Docker path.

![screenshot from 2015-06-25 20 55 00](https://cloud.githubusercontent.com/assets/478564/8362928/0b8d9da0-1b7c-11e5-9d44-3a5cc14589e9.png)

Now you can click the 'REMOVE' button to unlink the local folder (not new) or you can use the X button to remove completely the volume, which will re-create immediately the container (also there were a bug here with the `Binds` attribute of the Docker server API. It is now embedded in the `HostConfig` attribute while Kitematic was setting the `Binds` attribute at the root of the JSON).

![screenshot from 2015-06-25 20 57 33](https://cloud.githubusercontent.com/assets/478564/8362985/684461be-1b7c-11e5-9605-8f6f82aa0efb.png)

Last but not least, the 'RESET' button allow the user to revert the changes until he clicks the 'SAVE' button.
So let say the user add some volumes and use the 'CHANGE' button to link the local folder to the docker folder (clicking the 'EXEC' icon and list the folders in the terminal will show the new folders) but then he wants to rollback everything as it was before, he can click the 'RESET' button which will unlink and remove the folders automatically.