### PR TITLE
Local images support!

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,18 +17,18 @@ Before you file an issue or a pull request, read the following tips on how to ke
  - [License](#license)
 
 
-### Prerequisites for developing Kitematic on Mac 
-You will need to install: 
+### Prerequisites for developing Kitematic on Mac
+You will need to install:
 - The [Docker Toolbox](https://docker.com/toolbox)
 - [Node.js](https://nodejs.org/)
 - Wine `brew install wine` (only if you want to generate a Windows release on OS X)
-- The latest Xcode from the Apple App Store. 
+- The latest Xcode from the Apple App Store.
 
-### Prerequisites for developing Kitematic on Windows 
-You will need to install: 
+### Prerequisites for developing Kitematic on Windows
+You will need to install:
 - The [Docker Toolbox](https://docker.com/toolbox)
 - [Node.js](https://nodejs.org/)
-- Open a command prompt (`cmd`) and run the command `mkdir ~/AppData/Roaming/npm` 
+- Open a command prompt (`cmd`) and run the command `mkdir ~/AppData/Roaming/npm`
 - [Visual Studio 2013 Community](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx) (or similar) - You do not need to install any optional packages during install.
 - [Python](https://www.python.org/downloads/release/python-2710/)
 

--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -35,8 +35,8 @@ class ContainerActions {
     this.dispatch();
   }
 
-  run (name, repo, tag) {
-    dockerUtil.run(name, repo, tag);
+  run (name, repo, tag, local=false) {
+    dockerUtil.run(name, repo, tag, local);
   }
 
   active (name) {

--- a/src/actions/ImageActions.js
+++ b/src/actions/ImageActions.js
@@ -5,7 +5,7 @@ class ImageActions {
 
   all () {
     this.dispatch({});
-    dockerUtil.fetchAllImages();
+    dockerUtil.refresh();
   }
 
   destroy (image) {

--- a/src/actions/ImageActions.js
+++ b/src/actions/ImageActions.js
@@ -1,0 +1,16 @@
+import alt from '../alt';
+import dockerUtil from '../utils/DockerUtil';
+
+class ImageActions {
+
+  all () {
+    this.dispatch({});
+    dockerUtil.fetchAllImages();
+  }
+
+  destroy (image) {
+    dockerUtil.removeImage(image);
+  }
+}
+
+export default alt.createActions(ImageActions);

--- a/src/actions/ImageServerActions.js
+++ b/src/actions/ImageServerActions.js
@@ -1,0 +1,14 @@
+import alt from '../alt';
+
+class ImageServerActions {
+  constructor () {
+    this.generateActions(
+      'added',
+      'updated',
+      'destroyed',
+      'error'
+    );
+  }
+}
+
+export default alt.createActions(ImageServerActions);

--- a/src/actions/TagActions.js
+++ b/src/actions/TagActions.js
@@ -6,6 +6,10 @@ class TagActions {
     this.dispatch({repo});
     regHubUtil.tags(repo);
   }
+  
+  localTags (repo, tags) {
+    this.dispatch({repo, tags});
+  }
 }
 
 export default alt.createActions(TagActions);

--- a/src/components/ImageCard.react.js
+++ b/src/components/ImageCard.react.js
@@ -85,7 +85,7 @@ var ImageCard = React.createClass({
     $tagOverlay.fadeOut(300);
   },
   handleDeleteImgClick: function (image) {
-    if (this.state.chosenTag) {
+    if (this.state.chosenTag && !this.props.image.inUse) {
       imageActions.destroy(image.RepoTags[0].split(':')[0] + ':' + this.state.chosenTag);
     }
   },
@@ -164,8 +164,7 @@ var ImageCard = React.createClass({
       );
     }
 
-    let create;
-    let overlay;
+    let create, overlay;
     if (this.props.image.is_local) {
       create = (
         <div className="actions">
@@ -187,9 +186,9 @@ var ImageCard = React.createClass({
             <span className="icon icon-tag"></span><span className="text">SELECTED TAG: <span className="selected-tag">{this.state.chosenTag}</span></span>
           </div>
           <div className="remove" onClick={this.handleDeleteImgClick.bind(this, this.props.image)}>
-            <span className="btn btn-delete btn-action has-icon btn-hollow"><span className="icon icon-delete"></span>Delete Tag</span>
+            <span className="btn btn-delete btn-action has-icon btn-hollow" disabled={this.props.image.inUse ? 'disabled' : null}><span className="icon icon-delete"></span>Delete Tag</span>
           </div>
-          <p className="small">Prior to delete, stop all containers<br/>using the above tag</p>
+          {this.props.image.inUse ? <p className="small">To delete, remove all containers<br/>using the above image</p> : null }
           <div className="close-overlay">
             <a className="btn btn-action circular" onClick={self.handleCloseMenuOverlay}><span className="icon icon-delete"></span></a>
           </div>

--- a/src/components/NewContainerSearch.react.js
+++ b/src/components/NewContainerSearch.react.js
@@ -10,6 +10,8 @@ import repositoryActions from '../actions/RepositoryActions';
 import repositoryStore from '../stores/RepositoryStore';
 import accountStore from '../stores/AccountStore';
 import accountActions from '../actions/AccountActions';
+import imageActions from '../actions/ImageActions';
+import imageStore from '../stores/ImageStore';
 
 var _searchPromise = null;
 
@@ -20,6 +22,8 @@ module.exports = React.createClass({
       query: '',
       loading: repositoryStore.loading(),
       repos: repositoryStore.all(),
+      images: imageStore.all(),
+      imagesErr: imageStore.error,
       username: accountStore.getState().username,
       verified: accountStore.getState().verified,
       accountLoading: accountStore.getState().loading,
@@ -34,6 +38,7 @@ module.exports = React.createClass({
     this.refs.searchInput.getDOMNode().focus();
     repositoryStore.listen(this.update);
     accountStore.listen(this.updateAccount);
+    imageStore.listen(this.updateImage);
     repositoryActions.search();
   },
   componentWillUnmount: function () {
@@ -51,7 +56,14 @@ module.exports = React.createClass({
       currentPage: repositoryStore.getState().currentPage,
       totalPage: repositoryStore.getState().totalPage,
       previousPage: repositoryStore.getState().previousPage,
-      nextPage: repositoryStore.getState().nextPage
+      nextPage: repositoryStore.getState().nextPage,
+      error: repositoryStore.getState().error
+    });
+  },
+  updateImage: function (imgStore) {
+    this.setState({
+      images: imgStore.images,
+      error: imgStore.error
     });
   },
   updateAccount: function () {
@@ -79,7 +91,8 @@ module.exports = React.createClass({
       currentPage: page,
       previousPage: previousPage,
       nextPage: nextPage,
-      totalPage: totalPage
+      totalPage: totalPage,
+      error: null
     });
 
     _searchPromise = Promise.delay(200).cancellable().then(() => {
@@ -101,9 +114,15 @@ module.exports = React.createClass({
   },
   handleFilter: function (filter) {
 
+    this.setState({error: null});
+
     // If we're clicking on the filter again - refresh
     if (filter === 'userrepos' && this.getQuery().filter === 'userrepos') {
       repositoryActions.repos();
+    }
+
+    if (filter === 'userimages' && this.getQuery().filter === 'userimages') {
+      imageActions.all();
     }
 
     if (filter === 'recommended' && this.getQuery().filter === 'recommended') {
@@ -187,10 +206,16 @@ module.exports = React.createClass({
         </ul>
       </nav>
     ) : null;
+    let errorMsg = null;
+    if (this.state.error === null || this.state.error.message.indexOf('getaddrinfo ENOTFOUND') !== -1) {
+      errorMsg = 'There was an error contacting Docker Hub.';
+    } else {
+      errorMsg = this.state.error.message.replace('HTTP code is 409 which indicates error: conflict - ', '');
+    }
     if (this.state.error) {
       results = (
         <div className="no-results">
-          <h2>There was an error contacting Docker Hub.</h2>
+          <h2 className="error">{errorMsg}</h2>
         </div>
       );
       paginateResults = null;
@@ -268,6 +293,32 @@ module.exports = React.createClass({
           {otherResults}
         </div>
       );
+    } else if (filter === 'userimages') {
+      let userImageItems = this.state.images.map(image => {
+        let repo = image.RepoTags[0].split(':')[0];
+        if (repo.indexOf('/') === -1) {
+          repo = 'local/' + repo;
+        }
+        [image.namespace, image.name] = repo.split('/');
+        image.description = null;
+        let tags = image.tags.join('-');
+        image.star_count = 0;
+        image.is_local = true;
+        return (<ImageCard key={image.namespace + '/' + image.name + ':' + tags} image={image} chosenTag={image.tags[0]} tags={image.tags} />);
+      });
+      let userImageResults = userImageItems.length ? (
+        <div>
+          <h4>My Images</h4>
+          <div className="result-grid">
+            {userImageItems}
+          </div>
+        </div>
+      ) : null;
+      results = (
+        <div className="result-grids">
+          {userImageResults}
+        </div>
+      );
     } else {
       if (this.state.query.length) {
         results = (
@@ -316,6 +367,7 @@ module.exports = React.createClass({
               <span className={`results-filter results-all tab ${filter === 'all' ? 'active' : ''}`} onClick={this.handleFilter.bind(this, 'all')}>All</span>
               <span className={`results-filter results-recommended tab ${filter === 'recommended' ? 'active' : ''}`} onClick={this.handleFilter.bind(this, 'recommended')}>Recommended</span>
               <span className={`results-filter results-userrepos tab ${filter === 'userrepos' ? 'active' : ''}`} onClick={this.handleFilter.bind(this, 'userrepos')}>My Repos</span>
+              <span className={`results-filter results-userimages tab ${filter === 'userimages' ? 'active' : ''}`} onClick={this.handleFilter.bind(this, 'userimages')}>My Images</span>
             </div>
           </div>
           <div className="results">

--- a/src/components/NewContainerSearch.react.js
+++ b/src/components/NewContainerSearch.react.js
@@ -239,6 +239,34 @@ module.exports = React.createClass({
         </div>
       );
       paginateResults = null;
+    } else if (filter === 'userimages') {
+      let userImageItems = this.state.images.map(image => {
+        let repo = image.RepoTags[0].split(':')[0];
+        if (repo.indexOf('/') === -1) {
+          repo = 'local/' + repo;
+        }
+        [image.namespace, image.name] = repo.split('/');
+        image.description = null;
+        let tags = image.tags.join('-');
+        image.star_count = 0;
+        image.is_local = true;
+        return (<ImageCard key={image.namespace + '/' + image.name + ':' + tags} image={image} chosenTag={image.tags[0]} tags={image.tags} />);
+      });
+      let userImageResults = userImageItems.length ? (
+        <div className="result-grids">
+          <div>
+            <h4>My Images</h4>
+            <div className="result-grid">
+              {userImageItems}
+            </div>
+          </div>
+        </div>
+      ) : <div className="no-results">
+        <h2>Cannot find any local image.</h2>
+      </div>;
+      results = (
+          {userImageResults}
+      );
     } else if (this.state.loading) {
       results = (
         <div className="no-results">
@@ -293,32 +321,6 @@ module.exports = React.createClass({
           {otherResults}
         </div>
       );
-    } else if (filter === 'userimages') {
-      let userImageItems = this.state.images.map(image => {
-        let repo = image.RepoTags[0].split(':')[0];
-        if (repo.indexOf('/') === -1) {
-          repo = 'local/' + repo;
-        }
-        [image.namespace, image.name] = repo.split('/');
-        image.description = null;
-        let tags = image.tags.join('-');
-        image.star_count = 0;
-        image.is_local = true;
-        return (<ImageCard key={image.namespace + '/' + image.name + ':' + tags} image={image} chosenTag={image.tags[0]} tags={image.tags} />);
-      });
-      let userImageResults = userImageItems.length ? (
-        <div>
-          <h4>My Images</h4>
-          <div className="result-grid">
-            {userImageItems}
-          </div>
-        </div>
-      ) : null;
-      results = (
-        <div className="result-grids">
-          {userImageResults}
-        </div>
-      );
     } else {
       if (this.state.query.length) {
         results = (
@@ -350,17 +352,23 @@ module.exports = React.createClass({
       'icon-search': true,
       'search-icon': true
     });
+    let searchClasses = classNames('search-bar');
+    if (filter === 'userimages') {
+      searchClasses = classNames('search-bar', {
+        hidden: true
+      });
+    }
 
     return (
       <div className="details">
         <div className="new-container">
           <div className="new-container-header">
             <div className="search">
-              <div className="search-bar">
-                <input type="search" ref="searchInput" className="form-control" placeholder="Search for Docker images from Docker Hub" onChange={this.handleChange}/>
-                <div className={magnifierClasses}></div>
-                <div className={loadingClasses}><div></div></div>
-              </div>
+            <div className={searchClasses}>
+              <input type="search" ref="searchInput" className="form-control" placeholder="Search for Docker images from Docker Hub" onChange={this.handleChange}/>
+              <div className={magnifierClasses}></div>
+              <div className={loadingClasses}><div></div></div>
+            </div>
             </div>
             <div className="results-filters">
               <span className="results-filter results-filter-title">FILTER BY</span>

--- a/src/stores/ImageStore.js
+++ b/src/stores/ImageStore.js
@@ -37,6 +37,9 @@ class ImageStore {
         let [name, tag] = repoTags.split(':');
         if (typeof tags[name] !== 'undefined') {
           finalImages[tags[name]].tags.push(tag);
+          if (image.inUse) {
+            finalImages[tags[name]].inUse = image.inUse;
+          }
         } else {
           image.tags = [tag];
           tags[name] = finalImages.length;

--- a/src/stores/ImageStore.js
+++ b/src/stores/ImageStore.js
@@ -1,0 +1,56 @@
+import alt from '../alt';
+import imageActions from '../actions/ImageActions';
+import imageServerActions from '../actions/ImageServerActions';
+
+class ImageStore {
+  constructor () {
+    this.bindActions(imageActions);
+    this.bindActions(imageServerActions);
+    this.results = [];
+    this.images = [];
+    this.imagesLoading = false;
+    this.resultsLoading = false;
+    this.error = null;
+  }
+
+  error (error) {
+    this.setState({error: error, imagesLoading: false, resultsLoading: false});
+  }
+
+  clearError () {
+    this.setState({error: null});
+  }
+
+  destroyed (data) {
+    let images = this.images;
+    if ((data && data[1] && data[1].Deleted)) {
+      delete images[data[1].Deleted];
+    }
+    this.setState({error: null});
+  }
+
+  updated (images) {
+    let tags = {};
+    let finalImages = [];
+    images.map((image) => {
+      image.RepoTags.map(repoTags => {
+        let [name, tag] = repoTags.split(':');
+        if (typeof tags[name] !== 'undefined') {
+          finalImages[tags[name]].tags.push(tag);
+        } else {
+          image.tags = [tag];
+          tags[name] = finalImages.length;
+          finalImages.push(image);
+        }
+      });
+    });
+    this.setState({error: null, images: finalImages, imagesLoading: false});
+  }
+
+  static all () {
+    let state = this.getState();
+    return state.images;
+  }
+}
+
+export default alt.createStore(ImageStore);

--- a/src/stores/TagStore.js
+++ b/src/stores/TagStore.js
@@ -21,6 +21,15 @@ class TagStore {
     this.emitChange();
   }
 
+  localTags ({repo, tags}) {
+    let data = [];
+    tags.map((value) => {
+      data.push({'name': value});
+    });
+    this.loading[repo] = true;
+    this.tagsUpdated({repo, tags: data || []});
+  }
+
   tagsUpdated ({repo, tags}) {
     this.tags[repo] = tags;
     this.loading[repo] = false;

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -8,6 +8,8 @@ import util from './Util';
 import hubUtil from './HubUtil';
 import metrics from '../utils/MetricsUtil';
 import containerServerActions from '../actions/ContainerServerActions';
+import imageServerActions from '../actions/ImageServerActions';
+import Promise from 'bluebird';
 import rimraf from 'rimraf';
 import stream from 'stream';
 import JSONStream from 'JSONStream';
@@ -15,13 +17,14 @@ import Promise from 'bluebird';
 
 
 
-export default {
+var DockerUtil = {
   host: null,
   client: null,
   placeholders: {},
   stream: null,
   eventStream: null,
   activeContainerName: null,
+  localImages: null,
 
   setup (ip, name) {
     if (!ip && !name) {
@@ -77,6 +80,7 @@ export default {
   init () {
     this.placeholders = JSON.parse(localStorage.getItem('placeholders')) || {};
     this.fetchAllContainers();
+    this.fetchAllImages();
     this.listen();
 
     // Resume pulling containers that were previously being pulled
@@ -170,6 +174,7 @@ export default {
         });
       });
     });
+    this.fetchAllImages();
   },
 
   fetchContainer (id) {
@@ -210,7 +215,36 @@ export default {
     });
   },
 
-  run (name, repository, tag) {
+  fetchAllImages () {
+    this.client.listImages((err, list) => {
+      if (err) {
+        imageServerActions.error(err);
+      } else {
+        this.localImages = list;
+        imageServerActions.updated(list);
+      }
+    });
+  },
+
+  removeImage (selectedRepoTag) {
+    this.localImages.some((image) => {
+      image.RepoTags.map(repoTag => {
+        if (repoTag === selectedRepoTag) {
+          this.client.getImage(selectedRepoTag).remove({'force': true}, (err, data) => {
+            if (err) {
+              console.error(err);
+              imageServerActions.error(err);
+            } else {
+              imageServerActions.destroyed(data);
+            }
+          });
+          return true;
+        }
+      });
+    });
+  },
+
+  run (name, repository, tag, local = false) {
     tag = tag || 'latest';
     let imageName = repository + ':' + tag;
 
@@ -231,30 +265,33 @@ export default {
 
     this.placeholders[name] = placeholderData;
     localStorage.setItem('placeholders', JSON.stringify(this.placeholders));
-
-    this.pullImage(repository, tag, error => {
-      if (error) {
-        containerServerActions.error({name, error});
-        return;
-      }
-
-      if (!this.placeholders[name]) {
-        return;
-      }
-
+    if (local) {
       this.createContainer(name, {Image: imageName, Tty: true, OpenStdin: true});
-    },
+    } else {
+      this.pullImage(repository, tag, error => {
+        if (error) {
+          containerServerActions.error({name, error});
+          return;
+        }
 
-    // progress is actually the progression PER LAYER (combined in columns)
-    // not total because it's not accurate enough
-    progress => {
-      containerServerActions.progress({name, progress});
-    },
+        if (!this.placeholders[name]) {
+          return;
+        }
+
+        this.createContainer(name, {Image: imageName, Tty: true, OpenStdin: true});
+      },
+
+      // progress is actually the progression PER LAYER (combined in columns)
+      // not total because it's not accurate enough
+      progress => {
+        containerServerActions.progress({name, progress});
+      },
 
 
-    () => {
-      containerServerActions.waiting({name, waiting: true});
-    });
+      () => {
+        containerServerActions.waiting({name, waiting: true});
+      });
+    }
   },
 
   updateContainer (name, data) {
@@ -474,9 +511,11 @@ export default {
       }
 
       stream.setEncoding('utf8');
-      stream.pipe(JSONStream.parse()).on('data', data => {
-        if (data.status === 'pull' || data.status === 'untag' || data.status === 'delete' ||  data.status === 'attach') {
-          return;
+      stream.on('data', json => {
+        let data = JSON.parse(json);
+
+        if (data.status === 'pull' || data.status === 'untag' || data.status === 'delete' || data.status === 'attach') {
+          this.fetchAllImages();
         }
 
         if (data.status === 'destroy') {
@@ -519,6 +558,7 @@ export default {
 
     this.client.pull(repository + ':' + tag, opts, (err, stream) => {
       if (err) {
+        console.log('Err: %o', err);
         callback(err);
         return;
       }
@@ -563,7 +603,7 @@ export default {
               if (i < leftOverLayers) {
                 layerAmount += 1;
               }
-              columns.progress[i] = {layerIDs: [], nbLayers:0 , maxLayers: layerAmount, value: 0.0};
+              columns.progress[i] = {layerIDs: [], nbLayers: 0, maxLayers: layerAmount, value: 0.0};
             }
           }
 
@@ -617,3 +657,5 @@ export default {
     });
   }
 };
+
+module.exports = DockerUtil;

--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -167,6 +167,7 @@
       .results-userimages {
         border-left: 1px solid @gray-lighter;
         padding-left: 1.2rem;
+        padding-right: 1.2rem;
       }
     }
   }

--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -67,6 +67,10 @@
       justify-content: center;
       flex-shrink: 0;
 
+      .error {
+        color: red;
+      }
+
       img {
         width: 380px;
       }
@@ -160,6 +164,10 @@
         font-weight: 500;
         margin-right: 0.7rem;
       }
+      .results-userimages {
+        border-left: 1px solid @gray-lighter;
+        padding-left: 1.2rem;
+      }
     }
   }
 }
@@ -226,6 +234,31 @@
           position: absolute;
           bottom: 1rem;
           right: 1rem;
+        }
+        .remove {
+          display: flex;
+          flex: 1 auto;
+          justify-content: center;
+          margin: 0.8rem 0 0 0;
+          a {
+            display: block;
+            text-decoration: none;
+            cursor: default;
+            &:focus {
+              outline: 0;
+            }
+            &.active {
+              .btn-delete {
+                opacity: 0.3;
+              }
+            }
+          }
+        }
+        .small {
+          color: red;
+          text-align: center;
+          padding-top: 5px;
+          font-size: 75%;
         }
       }
       .tag-overlay {


### PR DESCRIPTION
This PR adds a new tab to the New Container view, allowing the user to:
* View all local images
* Create from local image (with tag selection)
* Delete local image

![list-images](https://cloud.githubusercontent.com/assets/3965324/9019310/820c154a-37b7-11e5-8d13-88f0ee3f1172.png)
![image-opt](https://cloud.githubusercontent.com/assets/3965324/9019313/876aabe6-37b7-11e5-9d8f-67887d0b4151.png)
![select-tag](https://cloud.githubusercontent.com/assets/3965324/9019316/8bb91c82-37b7-11e5-85f3-9dfa4070a9f5.png)
![image-created-tag](https://cloud.githubusercontent.com/assets/3965324/9019318/8e875de8-37b7-11e5-89f8-899a065f18fd.png)


Known issues:
* `docker build` currently doesn't trigger an event, an issue was open with the docker team to get this resolved
* All images are deleted, no single-tag image delete currently possible