### PR TITLE
Add package option for devTools window on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bugs": "https://github.com/kitematic/kitematic/issues",
   "scripts": {
     "start": "grunt",
+    "start-dev": "NODE_ENV=development grunt",
     "test": "jest -c jest-unit.json",
     "integration": "jest -c jest-integration.json",
     "release": "grunt release",

--- a/src/browser.js
+++ b/src/browser.js
@@ -53,6 +53,10 @@ app.on('ready', function () {
     show: false
   });
 
+  if (process.env.NODE_ENV === 'development') {
+    mainWindow.openDevTools({detach: true});
+  }
+
   mainWindow.loadUrl(path.normalize('file://' + path.join(__dirname, 'index.html')));
 
   app.on('activate-with-no-open-windows', function () {


### PR DESCRIPTION
Simple command line change to allow the dev tools to be open when the node env is set to development.
Can be started via command line: `npm run start-dev`

Signed-off-by: French Ben <me+git@frenchben.com>