### PR TITLE
Updated API calls for 1.22 and electron IPC update

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -2,7 +2,7 @@ import app from 'app';
 import BrowserWindow from 'browser-window';
 import fs from 'fs';
 import os from 'os';
-import ipc from 'ipc';
+var ipc = require('electron').ipcMain;
 import path from 'path';
 import child_process from 'child_process';
 
@@ -57,7 +57,7 @@ app.on('ready', function () {
     mainWindow.openDevTools({detach: true});
   }
 
-  mainWindow.loadUrl(path.normalize('file://' + path.join(__dirname, 'index.html')));
+  mainWindow.loadURL(path.normalize('file://' + path.join(__dirname, 'index.html')));
 
   app.on('activate-with-no-open-windows', function () {
     if (mainWindow) {

--- a/src/components/ContainerHomeFolders.react.js
+++ b/src/components/ContainerHomeFolders.react.js
@@ -41,7 +41,13 @@ var ContainerHomeFolder = React.createClass({
             }
           });
 
-          containerActions.update(this.props.container.Name, {Mounts: mounts});
+          let binds = mounts.map(m => {
+            return m.Source + ':' + m.Destination;
+          });
+
+          let hostConfig = _.extend(this.props.container.HostConfig, {Binds: binds});
+
+          containerActions.update(this.props.container.Name, {Mounts: mounts, HostConfig: hostConfig});
         }
       });
     } else {

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -31,6 +31,7 @@ var ContainerSettingsVolumes = React.createClass({
       _.each(mounts, m => {
         if (m.Destination === dockerVol) {
           m.Source = util.windowsToLinuxPath(directory);
+          m.Driver = null;
         }
       });
 
@@ -38,7 +39,9 @@ var ContainerSettingsVolumes = React.createClass({
         return m.Source + ':' + m.Destination;
       });
 
-      containerActions.update(this.props.container.Name, {Binds: binds, Mounts: mounts});
+      let hostConfig = _.extend(this.props.container.HostConfig, {Binds: binds});
+
+      containerActions.update(this.props.container.Name, {Mounts: mounts, HostConfig: hostConfig});
     });
   },
   handleRemoveVolumeClick: function (dockerVol) {
@@ -50,10 +53,17 @@ var ContainerSettingsVolumes = React.createClass({
     _.each(mounts, m => {
       if (m.Destination === dockerVol) {
         m.Source = null;
+        m.Driver = 'local';
       }
     });
 
-    containerActions.update(this.props.container.Name, {Mounts: mounts});
+    let binds = mounts.map(m => {
+      return m.Source + ':' + m.Destination;
+    });
+
+    let hostConfig = _.extend(this.props.container.HostConfig, {Binds: binds});
+
+    containerActions.update(this.props.container.Name, {Mounts: mounts, HostConfig: hostConfig});
   },
   handleOpenVolumeClick: function (path) {
     metrics.track('Opened Volume Directory', {


### PR DESCRIPTION
This fixes some of the port/binding and volume issue previously seen, by cleaning up the API calls to match the format found in remote api v1.22
See:
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#create-a-container

Signed-off-by: French Ben <me+git@frenchben.com>