### PR TITLE
This  change add a new method to the DockerUtil API to retrieve the v…

### DIFF
--- a/src/utils/SetupUtil.js
+++ b/src/utils/SetupUtil.js
@@ -59,6 +59,7 @@ export default {
     while (true) {
       try {
         docker.setup('localhost', machine.name());
+        await docker.version();
         docker.isDockerRunning();
 
         break;
@@ -146,6 +147,7 @@ export default {
 
         if (ip) {
           docker.setup(ip, machine.name());
+          await docker.version();
         } else {
           throw new Error('Could not determine IP from docker-machine.');
         }


### PR DESCRIPTION
…ersion from the docker server you are using. This is a blocking operation, so when you call the method you wait until the docker version is retrieved (or try it at most 10 times).

This method is called during the setup operation (both native and non native setup procedure), so you have to have a real connection to your docker daemon before you can go forward and this way to avoid synchronization issues as they are described on issue https://github.com/docker/kitematic/issues/1355

Signed-off-by: Alexandre Vázquez <alexandre.vazquez@gmail.com>