### PR TITLE
Fix stop the machine on close on Windows

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -7,10 +7,12 @@ import os from 'os';
 
 import path from 'path';
 import child_process from 'child_process';
+let Promise = require('bluebird');
 
 process.env.NODE_PATH = path.join(__dirname, 'node_modules');
 process.env.RESOURCES_PATH = path.join(__dirname, '/../resources');
 process.env.PATH = '/usr/local/bin:' + process.env.PATH;
+var exiting = false;
 
 var size = {}, settingsjson = {};
 try {
@@ -46,9 +48,15 @@ app.on('ready', function () {
   });
 
   if (os.platform() === 'win32') {
-    mainWindow.on('close', function () {
+    mainWindow.on('close', function (e) {
       mainWindow.webContents.send('application:quitting');
-      return true;
+      if(!exiting){
+        Promise.delay(1000).then(function(){
+          mainWindow.close();
+        });
+        exiting = true;
+        e.preventDefault();
+      }
     });
 
     app.on('window-all-closed', function () {


### PR DESCRIPTION
Introduce a delay and a two-step close windows procedure to allow to receive and execute the order to stop  the machine when Kitematic closes on Windows.