### PR TITLE
Use which to find docker-machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "request-progress": "^0.3.1",
     "rimraf": "^2.3.2",
     "underscore": "^1.8.3",
-    "validator": "^4.1.0"
+    "validator": "^4.1.0",
+    "which": "^1.2.4"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -24,7 +24,12 @@ var DockerMachine = {
     return 'default';
   },
   installed: function () {
-    return fs.existsSync(this.command());
+    try {
+      fs.accessSync(this.command(), fs.X_OK);
+      return true;
+    } catch (ex) {
+      return false;
+    }
   },
   version: function () {
     return util.execFile([this.command(), '-v']).then(stdout => {

--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -4,22 +4,26 @@ import Promise from 'bluebird';
 import fs from 'fs';
 import util from './Util';
 import child_process from 'child_process';
+import which from 'which';
 
 var DockerMachine = {
   command: function () {
     if (util.isWindows()) {
-      return path.join(process.env.DOCKER_TOOLBOX_INSTALL_PATH, 'docker-machine.exe');
-    } else {
-      return '/usr/local/bin/docker-machine';
+      if (process.env.DOCKER_TOOLBOX_INSTALL_PATH) {
+        return path.join(process.env.DOCKER_TOOLBOX_INSTALL_PATH, 'docker-machine.exe');
+      }
+    }
+
+    try {
+      return which.sync('docker-machine');
+    } catch (ex) {
+      return null;
     }
   },
   name: function () {
     return 'default';
   },
   installed: function () {
-    if (util.isWindows() && !process.env.DOCKER_TOOLBOX_INSTALL_PATH) {
-      return false;
-    }
     return fs.existsSync(this.command());
   },
   version: function () {


### PR DESCRIPTION
I started to build a [Chocolatey package for Kitematic](https://github.com/stefanScherer/choco-kitematic). But installing VirtualBox, docker-machine and then Kitematic through `choco install` doesn't work yet.

The problem is that Kitematic searches the `docker-machine` binary only with the environment variable `DOCKER_TOOLBOX_INSTALL_PATH`. After installing `docker-machine` with `choco install docker-machine` it is in the user's PATH.

So I enhanced the check to find `docker-machine` in the PATH if no such environment variable is set. The environment variable still has priority over the PATH to keep the same behaviour using the Docker Toolbox.

For Linux the `docker-machine` binary also is searched in PATH so it could be put to another place (perhaps someone compiles it from Go sources).
