### PR TITLE
Grammar fix, s/seem/seems/

### DIFF
--- a/src/components/ContainerHome.react.js
+++ b/src/components/ContainerHome.react.js
@@ -52,7 +52,7 @@ var ContainerHome = React.createClass({
     if (this.props.container.Error) {
       body = (
         <div className="details-progress error">
-          <h2>We&#39;re sorry. There seem to be an error:</h2>
+          <h2>We&#39;re sorry. There seems to be an error:</h2>
           <p className="error-message">{this.props.container.Error}</p>
           <p>If this error is invalid, please file a ticket on our Github repo.</p>
           <a className="btn btn-action" onClick={this.handleErrorClick}>File Ticket</a>


### PR DESCRIPTION
The subject of the sentence `an error` is singular, therefore `seems` should be used instead of `seem`.