### PR TITLE
Fix for menu bar not displaying in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "electron-version": "0.35.4",
   "dependencies": {
+
     "JSONStream": "^1.0.7",
     "alt": "^0.16.2",
     "ansi-to-html": "0.3.0",
@@ -55,6 +56,7 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-jest": "^5.2.0",
+    "electron-debug": "^0.5.0",
     "electron-prebuilt": "^0.36",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^3.3.0",

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,6 +6,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import child_process from 'child_process';
+import debug from 'electron-debug';
+debug();
 
 process.env.NODE_PATH = path.join(__dirname, 'node_modules');
 process.env.RESOURCES_PATH = path.join(__dirname, '/../resources');
@@ -30,8 +32,11 @@ app.on('ready', function () {
     'min-height': os.platform() === 'win32' ? 260 : 500,
     'standard-window': false,
     resizable: true,
-    frame: false,
-    show: false
+    frame: os.platform() === 'win32',
+    show: false,
+    autoHideMenuBar:true,
+    titleBarStyle: 'hidden',
+    icon:path.join(__dirname,'/../util/kitematic.ico')
   });
 
   if (process.env.NODE_ENV === 'development') {

--- a/src/components/Header.react.js
+++ b/src/components/Header.react.js
@@ -98,29 +98,23 @@ var Header = React.createClass({
     accountActions.verify();
   },
   renderLogo: function () {
-    return (
-      <div className="logo">
-        <RetinaImage src="logo.png"/>
-      </div>
-    );
+    if(!util.isWindows()) {
+      return (
+          <div className="logo">
+            <RetinaImage src="logo.png"/>
+          </div>
+      );
+    }
   },
   renderWindowButtons: function () {
     let buttons;
-    if (util.isWindows()) {
+    if (!util.isWindows()) {
       buttons = (
-        <div className="windows-buttons">
-        <div className="windows-button button-minimize enabled" onClick={this.handleMinimize}><div className="icon"></div></div>
-        <div className={`windows-button ${this.state.fullscreen ? 'button-fullscreenclose' : 'button-fullscreen'} enabled`} onClick={this.handleFullscreen}><div className="icon"></div></div>
-        <div className="windows-button button-close enabled" onClick={this.handleClose}></div>
-        </div>
-      );
-    } else {
-      buttons = (
-        <div className="buttons">
-        <div className="button button-close enabled" onClick={this.handleClose}></div>
-        <div className="button button-minimize enabled" onClick={this.handleMinimize}></div>
-        <div className="button button-fullscreen enabled" onClick={this.handleFullscreen}></div>
-        </div>
+          <div className="buttons">
+            <div className="button button-close enabled" onClick={this.handleClose}></div>
+            <div className="button button-minimize enabled" onClick={this.handleMinimize}></div>
+            <div className="button button-fullscreen enabled" onClick={this.handleFullscreen}></div>
+          </div>
       );
     }
     return buttons;
@@ -134,7 +128,7 @@ var Header = React.createClass({
     let username;
     if (this.props.hideLogin) {
       username = null;
-    } else if (this.state.username) {
+    } else if (this.state.username && !util.isWindows()) {
       username = (
         <div className="login-wrapper">
           <div className="login no-drag" onClick={this.handleUserClick}>
@@ -147,7 +141,7 @@ var Header = React.createClass({
           </div>
         </div>
       );
-    } else {
+    } else if(!util.isWindows()){
       username = (
         <div className="login-wrapper">
           <div className="login no-drag" onClick={this.handleLoginClick}>

--- a/src/menutemplate.js
+++ b/src/menutemplate.js
@@ -43,9 +43,6 @@ var MenuTemplate = function () {
         type: 'separator'
       },
       {
-        type: 'separator'
-      },
-      {
         label: 'Hide Kitematic',
         accelerator: util.CommandOrCtrl() + '+H',
         selector: 'hide:'


### PR DESCRIPTION
So I spent a couple days on this, and there are a couple problems. Firstly the main reason that the menu bar doesn't display in windows is because kitematic sets `frame:false` in the settings of the browser window. This prevents it from being displayed in Windows. So I implemented a fix. By removing the `frame:true` and changing it to `frame: os.platform() === 'win32'`, stuff started working. But there are a lot of UI problems. I tried to fix most of them. Here is a screen shot of what I have so far(And yes hiding the bar is supported with the `alt` key). 
![menubar](https://cloud.githubusercontent.com/assets/754720/13902742/5914eada-ee24-11e5-9e6e-1f6829607b2e.png)

Here is window before the alt key is pressed.
![withoutmenubar](https://cloud.githubusercontent.com/assets/754720/13902783/8e11fbae-ee26-11e5-8542-12bd1ae5c316.PNG)


The biggest problem is that I had to get rid of the header with the login and logo. I plan on putting back the information, I just want to make sure first that this is worth pursuing. If it is I would be curious to hear from some of the maintainers where the best place to put the rest of this information(I was thinking of putting it in top menu bar, or moving it to the bottom some where). I would be curious to here some thoughts. Thanks!
