### PR TITLE
Fix electron deprecated activate API

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -41,7 +41,7 @@ app.on('ready', function () {
 
   mainWindow.loadURL(path.normalize('file://' + path.join(__dirname, 'index.html')));
 
-  app.on('activate-with-no-open-windows', function () {
+  app.on('activate', function () {
     if (mainWindow) {
       mainWindow.show();
     }


### PR DESCRIPTION
Current code uses deprecated API from Electron. We should be using ```app.on('activate', function () {``` instead of ```app.on('activate-with-no-open-windows', function () {```.

This API change was in Electron v0.32.3 (https://github.com/electron/electron/commit/377e7ee3a728b5b8fe67605025fefc98cfd4f9f4) and we are currently using Electron v0.35.4 according to package.json.

I was getting the following deprecation error in the terminal when I hid the Kitematic window behind other applications and brought it back to the front. ```>> (electron) 'activate-with-no-open-windows' event is deprecated. Use 'activate' event instead.```

Signed-off-by: Clement Ho <ClemMakesApps@gmail.com>