### PR TITLE
Move deb rhel electron to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,6 @@
     "grunt-download-electron": "^2.1.1",
     "grunt-electron": "^2.0.0",
     "grunt-electron-installer": "^1.0.4",
-    "grunt-electron-installer-debian": "^0.3.0",
-    "grunt-electron-installer-redhat": "^0.3.0",
     "grunt-electron-packager": "0.0.7",
     "grunt-if-missing": "^1.0.0",
     "grunt-newer": "^1.1.1",
@@ -89,5 +87,9 @@
     "run-sequence": "^1.0.2",
     "shell-escape": "^0.2.0",
     "source-map-support": "^0.3.2"
+  },
+  "optionalDependencies": {
+    "grunt-electron-installer-debian": "^0.3.0",
+    "grunt-electron-installer-redhat": "^0.3.0"
   }
 }


### PR DESCRIPTION
Grunt-electron-installer modules for debian and redhat will not install on windows unless we move them to optionalDependencies in package.json. Grunt file will error on those platforms if the modules fail to install for some other reason than operating system.

Signed-off-by: Ben Harris benhdev@gmail.com