### PR TITLE
Fix duplicate react key issue

### DIFF
--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -36,9 +36,11 @@ module.exports = React.createClass({
   },
 
   render: function () {
-    let logs = this.props.container.Logs ?
-        this.props.container.Logs.map((l) => <div key={l.substr(0,l.indexOf(' '))} dangerouslySetInnerHTML={{__html: convert.toHtml(escape(l.substr(l.indexOf(' ')+1)).replace(/ /g, '&nbsp;<wbr>'))}}></div>) :
-        ['0 No logs for this container.'];
+    let logs = this.props.container.Logs ? this.props.container.Logs.map((l, index) => {
+        const key = `${this.props.container.Name}-${index}`;
+        return <div key={key} dangerouslySetInnerHTML={{__html: convert.toHtml(escape(l.substr(l.indexOf(' ')+1)).replace(/ /g, '&nbsp;<wbr>'))}}></div>;
+      }) : ['0 No logs for this container.'];
+
     return (
       <div className="mini-logs wrapper">
         <div className="widget">


### PR DESCRIPTION
This resolves issue #1713. It was caused by duplicate React keys for dynamic elements, so I replaced the existing keys with the following keys (which shouldn't overlap since we do not allow multiple containers with the same name):

`${ContainerName}-${lineNumber}`

Signed-off-by: Clement Ho <ClemMakesApps@gmail.com>