### PR TITLE
Only animate the running and restarting icon five times. Continuously…

### DIFF
--- a/styles/left-panel.less
+++ b/styles/left-panel.less
@@ -219,7 +219,7 @@
             .at2x('runningwave.png', @container-state-size, @container-state-size);
             -webkit-animation-name: translatewave;
             -webkit-animation-duration: 7.0s;
-            -webkit-animation-iteration-count: infinite;
+            -webkit-animation-iteration-count: 5;
             -webkit-animation-timing-function: linear;
           }
         }
@@ -232,7 +232,7 @@
           -webkit-animation-delay: -1s;
           -webkit-animation-name: rotate;
           -webkit-animation-duration: 3.0s;
-          -webkit-animation-iteration-count: infinite;
+          -webkit-animation-iteration-count: 5;
           -webkit-animation-timing-function: linear;
         }
       }


### PR DESCRIPTION
… animating loads the CPU a lot and we can use the cycles better somewhere else.