### PR TITLE
Allow empty host port to unbind from PortBindings

### DIFF
--- a/src/components/ContainerSettingsPorts.react.js
+++ b/src/components/ContainerSettingsPorts.react.js
@@ -99,7 +99,9 @@ var ContainerSettingsPorts = React.createClass({
       return (i !== key && _.isEqual(v.port, port));
     });
 
-    if (!port.match(/^[0-9]+$/g)) {
+    if (port.length === 0) {
+      ports[key].error = null;
+    } else if (!port.match(/^[0-9]+$/g)) {
       ports[key].error = 'Needs to be an integer.';
     } else if (port <= 0 || port > 65535) {
       ports[key].error = 'Needs to be in range <1,65535>.';
@@ -173,7 +175,7 @@ var ContainerSettingsPorts = React.createClass({
     this.setState({ports: ports});
     let exposedPorts = {};
     let portBindings = _.reduce(ports, (res, value, key) => {
-      if (key !== '') {
+      if (key !== '' && value.port !== '') {
         res[key + '/' + value.portType] = [{
           HostPort: value.port
         }];


### PR DESCRIPTION
After random host port set, I couldn't remove it from PortBindings via kitematic
even when I don't need port exposed. (with help of nginx-proxy or something)

This diff allow to inpurt blank host port in Ports tab,
and ignore blank one on setting docker HostConfig.