### PR TITLE
Remove redundant http:// formatting

### DIFF
--- a/src/components/ContainerSettingsPorts.react.js
+++ b/src/components/ContainerSettingsPorts.react.js
@@ -116,7 +116,7 @@ var ContainerSettingsPorts = React.createClass({
     let port = e.target.value;
     // save updated port
     ports[key] = _.extend(ports[key], {
-      url: 'http://' + ports[key].ip + ':' + port,
+      url: ports[key].ip + ':' + port,
       port: port,
       error: null
     });


### PR DESCRIPTION
This resolves issue #1779.

The redundant `http://` url formatting when the port is updated is forcing the browser to open URLs with multiple `http://` prefixes. 

For example `http://http://localhost:3000`. The browser parses this url and attempts to load `http//localhost:3000` which fails. 

[http://http://google.com](http://http://google.com) does not equal [http://google.com](http://google.com)

Signed-off-by: Clement Ho <ClemMakesApps@gmail.com>