### PR TITLE
Honor DOCKER_CERT_PATH environment in nonNativeSetup

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -47,7 +47,7 @@ var DockerUtil = {
         throw new Error('Cannot connect to the Docker daemon. Is the daemon running?');
       }
     } else {
-      let certDir = path.join(util.home(), '.docker/machine/machines/', name);
+      let certDir = process.env.DOCKER_CERT_PATH || path.join(util.home(), '.docker/machine/machines/', name);
       if (!fs.existsSync(certDir)) {
         throw new Error('Certificate directory does not exist');
       }


### PR DESCRIPTION
Previously only certificates relative to the home folder
were honored, which made using custom storage locations
via MACHINE_STORAGE_PATH for docker machines quite
cumbersome to use.

This helps with the issue #1640.