### PR TITLE
Fix windows connection setup and port publish

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -157,7 +157,10 @@ var DockerUtil = {
       }
 
       if (!containerData.HostConfig || (containerData.HostConfig && !containerData.HostConfig.PortBindings)) {
-        containerData.PublishAllPorts = true;
+        if (!containerData.HostConfig) {
+          containerData.HostConfig = {};
+        }
+        containerData.HostConfig.PublishAllPorts = true;
       }
 
       if (image.Config.Cmd) {

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -35,11 +35,7 @@ var DockerUtil = {
     if (ip.indexOf('local') !== -1) {
       try {
         if (util.isWindows()) {
-          this.client = new dockerode({
-            protocol: 'http',
-            host: ip,
-            port: 2375
-          });
+          this.client = new dockerode({socketPath: '//./pipe/docker_engine'});
         } else {
           this.client = new dockerode({socketPath: '/var/run/docker.sock'});
         }

--- a/src/utils/SetupUtil.js
+++ b/src/utils/SetupUtil.js
@@ -91,7 +91,7 @@ export default {
     while (true) {
       try {
         router.get().transitionTo('setup');
-        docker.setup(util.isWindows() ? 'docker.local':'localhost');
+        docker.setup('localhost');
         setupServerActions.started({started: true});
         this.simulateProgress(20);
         metrics.track('Native Setup Finished');

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -43,7 +43,7 @@ module.exports = {
     if (this.native === null) {
       if (this.isWindows()) {
         this.native = http.get({
-          url: `http:////./pipe/docker_engine/v1.23/version`
+          url: `http:////./pipe/docker_engine/version`
         }, (response) => {
           if (response.statusCode !== 200 ) {
             return false;


### PR DESCRIPTION
Fixes #1836 

Previous Docker for Windows versions didn't use `localhost` as the endpoint, which required some extra logic. With the latest release it's been fixed and thus allows for common functionality.