### PR TITLE
Honor MACHINE_STORAGE_PATH environment for virtualBoxLogs

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -177,7 +177,14 @@ var DockerMachine = {
     }
   },
   virtualBoxLogs: function (machineName = this.name()) {
-    let logsPath = path.join(util.home(), '.docker', 'machine', 'machines', machineName, machineName, 'Logs', 'VBox.log');
+    
+    var logsPath = null;
+    if (process.env.MACHINE_STORAGE_PATH) {
+      logsPath = path.join(process.env.MACHINE_STORAGE_PATH, 'machines', machineName, machineName, 'Logs', 'VBox.log');
+    } else {
+      logsPath = path.join(util.home(), '.docker', 'machine', 'machines', machineName, machineName, 'Logs', 'VBox.log'); 
+    }
+
     let logData = null;
     try {
       logData = fs.readFileSync(logsPath, 'utf8');


### PR DESCRIPTION
Previously vbox log files were only stored beneath the .docker folder
relative to the user's home-directory which potentially resulted in
filenotfound errors.

We now store the vbox log files relative to the MACHINE_STORAGE_PATH
for docker machines, e.g. on windows
with `MACHINE_STORAGE_PATH` set to `C:\dev\docker\machine`
the logs for the `default` vm would be written to
`C:\dev\docker\machine\machines\default\default\Logs\VBox.log`

Signed-off-by: Thomas Darimont <thomas.darimont@gmail.com>