### PR TITLE
Electron debian fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -317,15 +317,36 @@ module.exports = function (grunt) {
     },
     'electron-installer-debian': {
       options: {
-        productName: LINUX_APPNAME,
+        name: BASENAME.toLowerCase(), // spaces and brackets cause linting errors
+        productName: LINUX_APPNAME.toLowerCase(),
         productDescription: 'Run containers through a simple, yet powerful graphical user interface.',
+        maintainer: 'Ben French <frenchben@docker.com>',
         section: 'devel',
         priority: 'optional',
         icon: './util/kitematic.png',
         lintianOverrides: [
           'changelog-file-missing-in-native-package',
           'executable-not-elf-or-script',
-          'extra-license-file'
+          'extra-license-file',
+          //File permission overrides
+          'non-standard-dir-perm',
+          'non-standard-file-perm',
+          'non-standard-executable-perm',
+          'script-not-executable',
+          'shlib-with-executable-bit',
+
+          'binary-without-manpage', //Kitematic does not have a manpage
+
+          'debian-changelog-file-missing', //incorrectly reports the debian changelog file as missing (probably looking in the wrong place)
+          'unusual-interpreter', //node does not appear as a "known" interpreter to lintian
+          'wrong-path-for-interpreter', //certain node_modules have hardcoded paths rather than using #!/usr/bin/env NAME
+          'backup-file-in-package', //node_modules contain README.md~, probably from npm packing
+          'package-contains-vcs-control-file', //node_modules contain .git folders, again, probably left over from npm packing
+
+          'embedded-javascript-library', //I'm assuming that JS libs are embedded intentionally into the Kitematic release
+          'embedded-library', //Ditto for embedded libaries like libnode and libgcrypt
+          'arch-dependent-file-in-usr-share' //for architecture (amd64 vs i386) specific .so libraries
+
         ],
         categories: [
           'Utility'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -328,25 +328,20 @@ module.exports = function (grunt) {
           'changelog-file-missing-in-native-package',
           'executable-not-elf-or-script',
           'extra-license-file',
-          //File permission overrides
           'non-standard-dir-perm',
           'non-standard-file-perm',
           'non-standard-executable-perm',
           'script-not-executable',
           'shlib-with-executable-bit',
-
-          'binary-without-manpage', //Kitematic does not have a manpage
-
-          'debian-changelog-file-missing', //incorrectly reports the debian changelog file as missing (probably looking in the wrong place)
-          'unusual-interpreter', //node does not appear as a "known" interpreter to lintian
-          'wrong-path-for-interpreter', //certain node_modules have hardcoded paths rather than using #!/usr/bin/env NAME
-          'backup-file-in-package', //node_modules contain README.md~, probably from npm packing
-          'package-contains-vcs-control-file', //node_modules contain .git folders, again, probably left over from npm packing
-
-          'embedded-javascript-library', //I'm assuming that JS libs are embedded intentionally into the Kitematic release
-          'embedded-library', //Ditto for embedded libaries like libnode and libgcrypt
-          'arch-dependent-file-in-usr-share' //for architecture (amd64 vs i386) specific .so libraries
-
+          'binary-without-manpage',
+          'debian-changelog-file-missing',
+          'unusual-interpreter',
+          'wrong-path-for-interpreter',
+          'backup-file-in-package',
+          'package-contains-vcs-control-file',
+          'embedded-javascript-library',
+          'embedded-library',
+          'arch-dependent-file-in-usr-share'
         ],
         categories: [
           'Utility'


### PR DESCRIPTION
This fixes the lintian linter errors for the debian package so that it can be installed from the .deb package without tripping the linter. You can check that it passes the linting with 
`lintian Kitematic_0.12.1_amd64.deb `. 

I had to resort to overriding most of the linting messages because they were related either to the way electron packager does the packaging or the Kitematic's module dependencies, both of which are out of scope of a localized fix. You can see the 14 error messages with `lintian --display-level=">=important" -o  Kitematic_0.12.1_amd64.deb`. Most have to do with the embedded libraries.

I've left a comment for each override in the first commit and removed them and collapsed the overrides in the second commit to keep everything clean. 

This bit is kind of **important** - I haven't been able to find a mailing address for Kitematic so I used yours for the maintainer field. 

To finish off, the package should now work properly in Debian, though some things, such as the permission fixes and moving the non-JS libraries out of the package and leaving them as external dependencies should be considered for the future.

