### PR TITLE
Change 'Hide Others' OS X/macOS shortcut to conventional ⌥⌘H [minor]

### DIFF
--- a/src/menutemplate.js
+++ b/src/menutemplate.js
@@ -52,7 +52,7 @@ var MenuTemplate = function () {
       },
       {
         label: 'Hide Others',
-        accelerator: util.CommandOrCtrl() + '+Shift+H',
+        accelerator: util.CommandOrCtrl() + '+Alt+H',
         selector: 'hideOtherApplications:'
       },
       {


### PR DESCRIPTION
The previous shortcut, `⇧⌘H`, is not conventional on OS X/macOS, so this simply changes the shift modified to alt/option, per the [OS X Human Interface Guidelines][hig]:

[hig]: https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/MenuBarMenus.html#//apple_ref/doc/uid/20000957-CH29-SW3

<img width="356" alt="hide-others" src="https://cloud.githubusercontent.com/assets/14554/17838399/e1678470-679a-11e6-98d1-73efc70039ca.png">
