### PR TITLE
Add engines entry to package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-    - "4.2.2"
+    - "4.1.1"
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "electron-version": "0.35.4",
+  "engines" : { "node" : "4.1.1" },
   "dependencies": {
     "alt": "^0.16.2",
     "ansi-to-html": "0.3.0",


### PR DESCRIPTION
Fixes #1944

This adds an engines entry to package.json. It's set to 4.1.1 which is the node version used in all electron versions between [0.33.2](https://github.com/electron/electron/releases/tag/v0.33.2) and [0.36.0](https://github.com/electron/electron/releases/tag/v0.36.0) what covers the current ([0.35.4](https://github.com/docker/kitematic/blob/master/package.json#L23)).

--

This actually brings up the question why the tests on travis [run against 4.2.2](https://github.com/docker/kitematic/blob/master/.travis.yml#L5) as that isn't the node version kitematic actually runs on doesn't it?