### PR TITLE
click 'X' to close a preview

### DIFF
--- a/src/components/ContainerHomeFolders.react.js
+++ b/src/components/ContainerHomeFolders.react.js
@@ -12,9 +12,18 @@ const dialog = remote.dialog;
 import mkdirp from 'mkdirp';
 
 var ContainerHomeFolder = React.createClass({
+  getInitialState: function () {
+    return {display: true};
+  },
+
   contextTypes: {
     router: React.PropTypes.func
   },
+
+  handleClickClose: function () {
+    this.setState({display: false});
+  },
+
   handleClickFolder: function (source, destination) {
     metrics.track('Opened Volume Directory', {
       from: 'home'
@@ -57,14 +66,16 @@ var ContainerHomeFolder = React.createClass({
       shell.showItemInFolder(path);
     }
   },
+
   handleClickChangeFolders: function () {
     metrics.track('Viewed Volume Settings', {
       from: 'preview'
     });
     this.context.router.transitionTo('containerSettingsVolumes', {name: this.context.router.getCurrentParams().name});
   },
+
   render: function () {
-    if (!this.props.container) {
+    if (!this.props.container || !this.state.display) {
       return false;
     }
 
@@ -84,6 +95,9 @@ var ContainerHomeFolder = React.createClass({
         <div className="widget">
           <div className="top-bar">
             <div className="text">Volumes</div>
+            <div className="action" onClick={this.handleClickClose}>
+              <span className="icon icon-delete"></span>
+            </div>
             <div className="action" onClick={this.handleClickChangeFolders}>
               <span className="icon icon-preferences"></span>
             </div>

--- a/src/components/ContainerHomeIpPortsPreview.react.js
+++ b/src/components/ContainerHomeIpPortsPreview.react.js
@@ -2,46 +2,61 @@ import _ from 'underscore';
 import React from 'react/addons';
 
 var ContainerHomeIpPortsPreview = React.createClass({
+  getInitialState: function () {
+    return {display: true};
+  },
+
+  handleClickClose: function () {
+    this.setState({display: false});
+  },
+
   handleClickPortSettings: function () {
     this.props.handleClickPortSettings();
   },
 
   render: function () {
-    var ports = _.map(_.pairs(this.props.ports), pair => {
-      var key = pair[0];
-      var val = pair[1];
-      return (
-          <tr key={key}>
+    if (!this.state.display) {
+      return false;
+    } else {
+      var ports = _.map(_.pairs(this.props.ports), pair => {
+        var key = pair[0];
+        var val = pair[1];
+        return (
+            <tr key={key}>
             <td>{key + '/' + val.portType}</td>
             <td>{val.url}</td>
-          </tr>
-      );
-    });
+            </tr>
+        );
+      });
 
-    return (
-      <div className="web-preview wrapper">
-        <div className="widget">
-          <div className="top-bar">
-            <div className="text">IP & PORTS</div>
-            <div className="action" onClick={this.handleClickPortSettings}>
-              <span className="icon icon-preferences"></span>
+      return (
+        <div className="web-preview wrapper">
+          <div className="widget">
+            <div className="top-bar">
+              <div className="text">IP & PORTS</div>
+              <div className="action" onClick={this.handleClickClose}>
+                <span className="icon icon-delete"></span>
+              </div>
+              <div className="action" onClick={this.handleClickPortSettings}>
+                <span className="icon icon-preferences"></span>
+              </div>
             </div>
+            <p>You can access this container using the following IP address and port:</p>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>DOCKER PORT</th>
+                  <th>ACCESS URL</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ports}
+              </tbody>
+            </table>
           </div>
-          <p>You can access this container using the following IP address and port:</p>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>DOCKER PORT</th>
-                <th>ACCESS URL</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ports}
-            </tbody>
-          </table>
         </div>
-      </div>
-    );
+      );
+    }
   }
 });
 

--- a/src/components/ContainerHomeWebPreview.react.js
+++ b/src/components/ContainerHomeWebPreview.react.js
@@ -3,6 +3,14 @@ import metrics from '../utils/MetricsUtil';
 import shell from 'shell';
 
 var ContainerHomeWebPreview = React.createClass({
+  getInitialState: function () {
+    return {display: true};
+  },
+
+  handleClickClose: function () {
+    this.setState({display: false});
+  },
+
   handleClickPreview: function () {
     metrics.track('Opened In Browser', {
       from: 'preview'
@@ -14,25 +22,33 @@ var ContainerHomeWebPreview = React.createClass({
     this.props.handleClickPortSettings();
   },
 
- render: function () {
-    var frame = React.createElement('webview', {className: 'frame', id: 'webview', src: 'http://' + this.props.ports[this.props.defaultPort].url, autosize: 'on'});
-    return (
-      <div className="web-preview wrapper">
-        <div className="widget">
-          <div className="top-bar">
-            <div className="text">Web Preview</div>
-            <div className="action" onClick={this.handleClickPreview}>
-              <span className="icon icon-open-external"></span>
+  render: function () {
+    if(!this.state.display) {
+      return false;
+    } else {
+      var frame = React.createElement('webview', {className: 'frame', id: 'webview', src: 'http://' + this.props.ports[this.props.defaultPort].url, autosize: 'on'});
+
+      return (
+        <div className="web-preview wrapper">
+          <div className="widget">
+            <div className="top-bar">
+              <div className="text">Web Preview</div>
+              <div className="action" onClick={this.handleClickClose}>
+                <span className="icon icon-delete"></span>
+              </div>
+              <div className="action" onClick={this.handleClickPreview}>
+                <span className="icon icon-open-external"></span>
+              </div>
+              <div className="action" onClick={this.handleClickPortSettings}>
+                <span className="icon icon-preferences"></span>
+              </div>
             </div>
-            <div className="action" onClick={this.handleClickPortSettings}>
-              <span className="icon icon-preferences"></span>
-            </div>
+            {frame}
+            <div onClick={this.handleClickPreview} className="frame-overlay"></div>
           </div>
-          {frame}
-          <div onClick={this.handleClickPreview} className="frame-overlay"></div>
         </div>
-      </div>
-    );
+      );
+    }
   }
 });
 


### PR DESCRIPTION
This is a PR to re-open the conversation about #1455.

Things to consider for this feature:
1. Expand `.left` when all of the `.right` windows have been closed.
   
   a. This will allow the user to close the panels on the right side and expand the logs on the left. This is great for users with smaller screens that want to expand the logs that may be wrapping.
2. Add a way to re-open the panels on the `.right` instead of just close.
   
   a. Maybe a collapse/expand instead?
   
   b. As of now, the workaround is to click to another container and back again. The closed panel will reappear.
3. Save the open/closed state for the panels.
   
   a. Once we have a way to reopen a panel (above), save the open/closed state such that moving away from the container and back, will not show the panel again.

Signed-off-by: Matthew Boston matthew@matthewboston.com
