### PR TITLE
improve linux terminal link error message

### DIFF
--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -207,7 +207,7 @@ module.exports = {
       dialog.showMessageBox({
         type: 'warning',
         buttons: ['OK'],
-        message: 'The terminal emulator symbolic link doesn\'t exists. Please read the Wiki at https://github.com/docker/kitematic/wiki/Early-Linux-Support.'
+        message: 'The symbolic link /usr/bin/x-terminal-emulator does not exist. Please read the Wiki at https://github.com/docker/kitematic/wiki/Early-Linux-Support for more information.'
       });
       return false;
     }


### PR DESCRIPTION
After clicking on the `exec`-Button, a message popped up, stating `The terminal emulator symbolic link doesn\'t exists. Please read the Wiki at https://github.com/docker/kitematic/wiki/Early-Linux-Support.`.

Sadly:
1.  the message gives no indication of the problem.
2.  The link given in the message, points to the wiki-site [Early-Linux-Support](https://github.com/docker/kitematic/wiki/Early-Linux-Support), which is except a link is empty
3.  The Link contains an anchor [#early-linux-support-from-zedtux](https://github.com/kitematic/kitematic/wiki/Common-Issues-and-Fixes#early-linux-support-from-zedtux), which does not exist on the linked  Wiki-Site.

I got my indication out of #1648.

It may also be good to remove the bad links in the message (and) remove the bad wiki-pages.
