### PR TITLE
Add tab with configuring container networks

### DIFF
--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -35,8 +35,8 @@ class ContainerActions {
     this.dispatch();
   }
 
-  run (name, repo, tag, local=false) {
-    dockerUtil.run(name, repo, tag, local);
+  run (name, repo, tag, network, local=false) {
+    dockerUtil.run(name, repo, tag, network, local);
   }
 
   active (name) {

--- a/src/actions/NetworkActions.js
+++ b/src/actions/NetworkActions.js
@@ -1,0 +1,14 @@
+import alt from '../alt';
+
+class NetworkActions {
+  constructor () {
+    this.generateActions(
+      'updated',
+      'error',
+      'pending',
+      'clearPending'
+    );
+  }
+}
+
+export default alt.createActions(NetworkActions);

--- a/src/components/ContainerSettings.react.js
+++ b/src/components/ContainerSettings.react.js
@@ -55,6 +55,11 @@ var ContainerSettings = React.createClass({
                   Volumes
                 </li>
               </Router.Link>
+              <Router.Link to="containerSettingsNetwork" params={{name: container.Name}}>
+                <li>
+                  Network
+                </li>
+              </Router.Link>
               <Router.Link to="containerSettingsAdvanced" params={{name: container.Name}}>
                 <li>
                   Advanced

--- a/src/components/ContainerSettingsNetwork.react.js
+++ b/src/components/ContainerSettingsNetwork.react.js
@@ -1,0 +1,144 @@
+import _ from 'underscore';
+import React from 'react/addons';
+import metrics from '../utils/MetricsUtil';
+import docker from '../utils/DockerUtil';
+import containerActions from '../actions/ContainerActions';
+import networkStore from '../stores/NetworkStore';
+
+var ContainerSettingsNetwork = React.createClass({
+  mixins: [React.addons.LinkedStateMixin],
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  getInitialState: function () {
+    let usedNetworks = this.getUsedNetworks(networkStore.all());
+    return {
+      networks: networkStore.all(),
+      error: networkStore.getState().error,
+      pending: networkStore.getState().pending,
+      usedNetworks
+    };
+  },
+
+  getUsedNetworks(networks) {
+    const usedKeys = _.keys(this.props.container.NetworkSettings.Networks);
+
+    return _.object(_.map(networks, function (network) {
+      return [network.Name, _.contains(usedKeys, network.Name)];
+    }));
+  },
+
+  componentDidMount: function () {
+    networkStore.listen(this.update);
+  },
+
+  componentWillUnmount: function () {
+    networkStore.unlisten(this.update);
+  },
+
+  update: function () {
+    let newState = {
+      networks: networkStore.all(),
+      error: networkStore.getState().error,
+      pending: networkStore.getState().pending
+    }; 
+    if (!newState.pending) {
+      newState.usedNetworks = this.getUsedNetworks(networkStore.all());
+    }
+    this.setState(newState);
+  },
+
+  handleSaveNetworkOptions: function () {
+    metrics.track('Saved Network Options');
+    let connectedNetworks = [];
+    let disconnectedNetworks = [];
+    let containerNetworks = this.props.container.NetworkSettings.Networks;
+    let usedNetworks = this.state.usedNetworks;
+    _.each(networkStore.all(), network => {
+      let isConnected = _.has(containerNetworks, network.Name);
+      if (isConnected !== usedNetworks[network.Name]) {
+        if (isConnected) {
+          disconnectedNetworks.push(network.Name);
+        } else {
+          connectedNetworks.push(network.Name);
+        }
+      }
+    });
+    if (connectedNetworks.length || disconnectedNetworks.length) {
+      docker.updateContainerNetworks(this.props.container.Name, connectedNetworks, disconnectedNetworks);
+    }
+  },
+
+  handleToggleNetwork: function (event) {
+    let usedNetworks = _.clone(this.state.usedNetworks);
+    let networkName = event.target.name;
+    let newState = !usedNetworks[networkName];
+    if (newState) {
+      if (networkName === 'none') {
+        usedNetworks = _.mapObject(usedNetworks, () => false);
+      } else {
+        usedNetworks['none'] = false;
+      }
+    }
+    usedNetworks[networkName] = newState;
+    this.setState({
+      usedNetworks
+    });
+  },
+
+  handleToggleHostNetwork: function () {
+    let NetworkingConfig = {
+      EndpointsConfig: {}
+    };
+    if (!this.state.usedNetworks.host) {
+      NetworkingConfig.EndpointsConfig.host = {};
+    }
+    containerActions.update(this.props.container.Name, {NetworkingConfig});
+  },
+
+  render: function () {
+    let isUpdating = (this.props.container.State.Updating || this.state.pending);
+    let networks = _.map(this.state.networks, (network, index) => {
+      if (network.Name !== 'host') {
+        return (
+          <tr key={network.Id}>
+            <td><input type="checkbox" disabled={isUpdating || this.state.usedNetworks.host} name={network.Name} checked={this.state.usedNetworks[network.Name]} onChange={this.handleToggleNetwork}/></td>
+            <td>{network.Name}</td>
+            <td>{network.Driver}</td>
+          </tr>
+        )
+      }
+    });
+
+    return (
+      <div className="settings-panel">
+        <div className="settings-section">
+          <h3>Configure network</h3>
+          <table className="table volumes">
+            <thead>
+              <tr>
+                <th>&nbsp;</th>
+                <th>NAME</th>
+                <th>DRIVER</th>
+              </tr>
+            </thead>
+            <tbody>
+              {networks}
+            </tbody>
+          </table>
+          { !this.state.usedNetworks.host ? <a className="btn btn-action" disabled={isUpdating} onClick={this.handleSaveNetworkOptions}>Save</a> : null }
+          { this.state.usedNetworks.host ? <span>You cannot configure networks while container connected to host network</span> : null }
+        </div>
+        <div className="settings-section">
+          <h3>Host network</h3>
+          { !this.state.usedNetworks.host ? <a className="btn btn-action" disabled={isUpdating} onClick={this.handleToggleHostNetwork}>Connect to host network</a> : null }
+          { this.state.usedNetworks.host ? <a className="btn btn-action" disabled={isUpdating} onClick={this.handleToggleHostNetwork}>Disconnect from host network</a> : null }
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ContainerSettingsNetwork;

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,6 +10,7 @@ import ContainerSettings from './components/ContainerSettings.react';
 import ContainerSettingsGeneral from './components/ContainerSettingsGeneral.react';
 import ContainerSettingsPorts from './components/ContainerSettingsPorts.react';
 import ContainerSettingsVolumes from './components/ContainerSettingsVolumes.react';
+import ContainerSettingsNetwork from './components/ContainerSettingsNetwork.react';
 import ContainerSettingsAdvanced from './components/ContainerSettingsAdvanced.react';
 import Preferences from './components/Preferences.react';
 import About from './components/About.react';
@@ -42,6 +43,7 @@ var routes = (
           <Route name="containerSettingsGeneral" path="general" handler={ContainerSettingsGeneral}/>
           <Route name="containerSettingsPorts" path="ports" handler={ContainerSettingsPorts}/>
           <Route name="containerSettingsVolumes" path="volumes" handler={ContainerSettingsVolumes}/>
+          <Route name="containerSettingsNetwork" path="network" handler={ContainerSettingsNetwork}/>
           <Route name="containerSettingsAdvanced" path="advanced" handler={ContainerSettingsAdvanced}/>
         </Route>
       </Route>

--- a/src/stores/NetworkStore.js
+++ b/src/stores/NetworkStore.js
@@ -1,0 +1,34 @@
+import alt from '../alt';
+import networkActions from '../actions/NetworkActions';
+
+class NetworkStore {
+  constructor () {
+    this.bindActions(networkActions);
+    this.networks = [];
+    this.pending = null;
+    this.error = null;
+  }
+
+  error (error) {
+    this.setState({error: error});
+  }
+
+  updated (networks) {
+    this.setState({error: null, networks: networks});
+  }
+
+  pending () {
+    this.setState({pending: true});
+  }
+
+  clearPending () {
+    this.setState({pending: null});
+  }
+
+  static all () {
+    let state = this.getState();
+    return state.networks;
+  }
+}
+
+export default alt.createStore(NetworkStore);

--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -218,7 +218,7 @@
           border-bottom: 1px solid @color-divider;
           height: 40px;
           .box-button();
-          .selected-tag {
+          .selected-item {
             color: @brand-primary;
             margin-left: 0.3rem;
           }
@@ -262,7 +262,7 @@
           font-size: 75%;
         }
       }
-      .tag-overlay {
+      .item-overlay {
         z-index: 1000;
         .close-overlay {
           position: absolute;
@@ -275,7 +275,7 @@
           margin-bottom: 0;
           border-bottom: 1px solid @color-divider;
         }
-        .tag-list {
+        .item-list {
           display: flex;
           flex-direction: row;
           align-items: flex-start;
@@ -284,7 +284,7 @@
           height: 90px;
           overflow: auto;
           padding: 0.5rem;
-          .tag {
+          .item {
             font-size: 11px;
             padding: 0.3rem 0.6rem;
             display: inline-block;
@@ -308,7 +308,7 @@
             }
           }
         }
-        .tags-loading {
+        .items-loading {
           position: relative;
           left: 45%;
           text-align: center;
@@ -318,7 +318,7 @@
           -webkit-animation-iteration-count: infinite;
           -webkit-animation-timing-function: linear;
         }
-        .no-tags {
+        .no-items {
           color: @gray-lighter;
           text-align: center;
           margin-top: 3rem;
@@ -416,7 +416,7 @@
               margin-right: 0.3rem;
             }
           }
-          .tags {
+          .items {
             flex: 1 auto;
             font-size: 11px;
             color: @gray-darker;


### PR DESCRIPTION
These PR add 2 features:
1. Saving network settings when container updates.
2. Configuring container network on separate tab in container settings.

Fixes #1249 

Signed-off-by: Vyacheslav Salakhutdinov <megazoll@gmail.com>