### PR TITLE
Add missing closing parenthesis

### DIFF
--- a/src/components/AccountLogin.react.js
+++ b/src/components/AccountLogin.react.js
@@ -28,7 +28,7 @@ module.exports = React.createClass({
   validate: function () {
     let errors = {};
 
-    if (this.state.username.indexOf('@') > -1 && !validator.isEmail(this.state.username) {
+    if (this.state.username.indexOf('@') > -1 && !validator.isEmail(this.state.username)) {
       errors.username = 'Must be a valid email';
     }
     else if (!validator.isLowercase(this.state.username) || !validator.isAlphanumeric(this.state.username) || !validator.isLength(this.state.username, 4, 30)) {


### PR DESCRIPTION
Hi. I was trying to run Kitematic on GNU/Linux and have noticed there's a paren missing that breaks the build, with Grunt complaining `src/components/AccountLogin.react.js: Unexpected token (31:54)`. This should fix it.