### PR TITLE
fix requires for rpm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,14 +380,22 @@ module.exports = function (grunt) {
       },
       linux64: {
         options: {
-          arch: 'x86_64'
+          arch: 'x86_64',
+          requires: [
+            'lsb-core-noarch',
+            'libXss.so.1()(64bit)'
+          ]
         },
         src: './dist/Kitematic-linux-x64/',
         dest: './dist/'
       },
       linux32: {
         options: {
-          arch: 'x86'
+          arch: 'x86',
+          requires: [
+            'lsb-core-noarch',
+            'libXss.so.1'
+          ]
         },
         src: './dist/Kitematic-linux-ia32/',
         dest: './dist/'


### PR DESCRIPTION
* use lsb-core-noarch to avoid qt3 dependency
  if we dependent on lsb. at CentOS7, it will require [redhat-lsb](https://centos.pkgs.org/7/centos-x86_64/redhat-lsb-4.1-27.el7.centos.1.x86_64.rpm.html), which require qt3([redhat-lsb](https://centos.pkgs.org/7/centos-x86_64/redhat-lsb-4.1-27.el7.centos.1.x86_64.rpm.html) -> [redhat-lsb-desktop](https://centos.pkgs.org/7/centos-x86_64/redhat-lsb-desktop-4.1-27.el7.centos.1.x86_64.rpm.html) -> [qt3](https://centos.pkgs.org/7/centos-x86_64/qt3-3.3.8b-51.el7.x86_64.rpm.html)).
  In [atom](https://github.com/atom/atom/blob/211b486a6fc31e8087635676e4683aad5cfcb551/resources/linux/redhat/atom.spec.in#L11), they require `lsb-core-noarch` instead of `lsb`, which work on CentOS, Fedora and OpenSUSE.
* use `libXss.so.1` as dependency to install at OpenSUSE
  If we dependent on `libXScrnSaver`, kitematic cannot installed at OpenSUSE(cause *`Problem: nothing provides libXScrnSaver needed by Kitematic-0.17.0-1.fc25.x86_64`*).
  So we use require `libXss.so.1` instead of `libXScrnSaver`.