### PR TITLE
Use local instead of local-library for local images namespace

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -291,7 +291,7 @@ var DockerUtil = {
             repo = imageSplit[0]+':'+imageSplit[1];
           }
           if (repo.indexOf('/') === -1) {
-            repo = 'local-library/' + repo;
+            repo = 'local/' + repo;
           }
           [list[idx].namespace, list[idx].name] = repo.split('/');
         });


### PR DESCRIPTION
Fixes #2870 

I think this was just a matter of the namespace being `local-library` instead of `local`.

![issue_2870](https://user-images.githubusercontent.com/8609429/32076812-1416ad9c-ba56-11e7-8d17-a8c2d4d032ae.gif)

**Note:** gif is a little long but should be good for proof that the change works.