### PR TITLE
Refactor local images view to handle dangling images

### DIFF
--- a/src/components/NewContainerSearch.react.js
+++ b/src/components/NewContainerSearch.react.js
@@ -240,17 +240,17 @@ module.exports = React.createClass({
       );
       paginateResults = null;
     } else if (filter === 'userimages') {
-      let userImageItems = this.state.images.map((image, index) => {
+      // filter out dangling images (aka images with no name/tag)
+      let validImages = this.state.images.filter((image) => image.name !== '<none>');
+      let userImageItems = validImages.map((image, index) => {
         image.description = null;
         let tags = image.tags.join('-');
         image.star_count = 0;
         image.is_local = true;
         const key = `local-${image.name}-${index}`;
-        let imageCard = null;
-        if (image.name !== '<none>') {
-          imageCard = (<ImageCard key={key + ':' + tags} image={image} chosenTag={image.tags[0]} tags={image.tags} />);
-        }
-        return imageCard;
+        return (
+          <ImageCard key={key + ':' + tags} image={image} chosenTag={image.tags[0]} tags={image.tags} />
+        );
       });
       let userImageResults = userImageItems.length ? (
         <div className="result-grids">
@@ -261,11 +261,13 @@ module.exports = React.createClass({
             </div>
           </div>
         </div>
-      ) : <div className="no-results">
-        <h2>Cannot find any local image.</h2>
-      </div>;
+      ) : (
+        <div className="no-results">
+          <h2>Cannot find any local image.</h2>
+        </div>
+      );
       results = (
-          {userImageResults}
+        {userImageResults}
       );
     } else if (this.state.loading) {
       results = (


### PR DESCRIPTION
Currently, if a user has no images (excluding dangling images), they still will see "My Images" on the "My Images" tab. Instead, they should see "Cannot find any local image."

This refactor aims to fix that and more explicitly filter out these dangling images.

Results of `docker images`:
```
maxhelmetag:~/ $ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              a0170d112f0c        5 months ago        520MB
<none>              <none>              6a0c8303ccb8        5 months ago        569MB
```

Before:
![screen shot 2017-10-29 at 12 21 52 pm](https://user-images.githubusercontent.com/8609429/32147401-eddf2f6e-bca3-11e7-94a1-e6ca076e3811.png)

After:
![screen shot 2017-10-29 at 12 21 15 pm](https://user-images.githubusercontent.com/8609429/32147403-f2257510-bca3-11e7-934c-733e528afe24.png)