### PR TITLE
Update eslint and eslintrc to not get sad when parsing async

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,11 +3,9 @@ root: true
 plugins:
     - react
 
-ecmaFeatures:
-    modules: true
-    jsx: true
-    arrowFunctions: true
-    blockBindings: true
+parserOptions:
+    ecmaVersion: 2017
+    sourceType: module
 
 env:
     node: true
@@ -101,10 +99,8 @@ rules:
 
     # Previously on by default in node environment
     no-catch-shadow: 0
-    no-console: 0
     no-mixed-requires: 2
     no-new-require: 2
     no-path-concat: 2
-    no-process-exit: 2
     global-strict: [0, "always"]
     handle-callback-err: [2, "err"]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "license": "Apache-2.0",
   "electron-version": "0.35.4",
-  "engines" : { "node" : "4.1.1" },
+  "engines": {
+    "node": "4.1.1"
+  },
   "dependencies": {
     "alt": "^0.16.2",
     "ansi-to-html": "0.3.0",
@@ -59,7 +61,7 @@
     "babel": "^5.8.23",
     "babel-jest": "^5.2.0",
     "electron-prebuilt": "^0.36",
-    "eslint": "^1.3.1",
+    "eslint": "^4.1.1",
     "eslint-plugin-react": "^3.3.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.1",


### PR DESCRIPTION
I was having a lot of trouble getting eslint to parse all the files in `src`. It seemed to be sad about the `async` keyword and then, after updating eslint, also `import` and `export`. This seems to have made it better.

I also would like to ask if people would be interested in converting the `.eslintrc` from YAML to JSON. I feel like the eslint docs don't really have YAML examples... which, IMO, can make config changes harder.