### PR TITLE
Add a way to download logs to file system

### DIFF
--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -88,7 +88,8 @@ module.exports = React.createClass({
     };
 
     let saveLogs = (event) => {
-      let path = `${this.props.container.Name}_logs.txt`;
+      //create default filename with timestamp
+      let path = `${this.props.container.Name} ${new Date().toISOString().replace(/T/, '_').replace(/\..+/, '').replace(/:/g,'-')}.txt`;
       dialog.showSaveDialog({
         defaultPath: path
       },function(fileName) {

--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -112,7 +112,9 @@ module.exports = React.createClass({
           <div className="top-bar">
             <div className="text">Container Logs</div>
             <div>
-                <button onClick={saveLogs}>Save</button>
+                <button className="save-logs__btn" onClick={saveLogs}>
+                  <i className="icon icon-download"></i>
+                </button>
                 <FontSelect fontSize={this.state.fontSize} onChange={this.onFontChange} />
                 <button className="copy-logs__btn" onClick={copyLogs}>Copy</button>
             </div>

--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -3,7 +3,9 @@ import React from 'react/addons';
 import Router from 'react-router';
 import containerActions from '../actions/ContainerActions';
 import Convert from 'ansi-to-html';
-const { clipboard } = require('electron');
+import * as fs from 'fs';
+import { clipboard, remote } from 'electron';
+const dialog = remote.dialog;
 
 let escape = function (html) {
   var text = document.createTextNode(html);
@@ -69,11 +71,11 @@ module.exports = React.createClass({
     let _logs = '';
     let logs = this.props.container.Logs ? this.props.container.Logs.map((l, index) => {
         const key = `${this.props.container.Name}-${index}`;
-        _logs = _logs.concat(escape(l.substr(l.indexOf(' ')+1)).replace(/\[\d+m/g,''));
+        _logs = _logs.concat((l.substr(l.indexOf(' ')+1)).replace(/\[\d+m/g,'').concat('\n'));
         return <div key={key} dangerouslySetInnerHTML={{__html: convert.toHtml(escape(l.substr(l.indexOf(' ')+1)).replace(/ /g, '&nbsp;<wbr>'))}}></div>;
       }) : ['0 No logs for this container.'];
 
-    let copyLogs = (event)=>{
+    let copyLogs = (event) => {
       clipboard.writeText(_logs);
 
       let btn = event.target;
@@ -85,12 +87,32 @@ module.exports = React.createClass({
       }, 1000);
     };
 
+    let saveLogs = (event) => {
+      let path = `${this.props.container.Name}_logs.txt`;
+      dialog.showSaveDialog({
+        defaultPath: path
+      },function(fileName) {
+        if (!fileName) return;
+        fs.writeFile(fileName, _logs, (err) => {
+          if(!!err){
+            dialog.showErrorBox('Oops! an error occured', err.message);
+          }else{
+            dialog.showMessageBox({
+              message: 'Container logs saved successfully.',
+              buttons: ['Ok']
+            });
+          }
+        });
+      });
+    };
+
     return (
       <div className="mini-logs wrapper">
         <div className="widget">
           <div className="top-bar">
             <div className="text">Container Logs</div>
             <div>
+                <button onClick={saveLogs}>Save</button>
                 <FontSelect fontSize={this.state.fontSize} onChange={this.onFontChange} />
                 <button className="copy-logs__btn" onClick={copyLogs}>Copy</button>
             </div>

--- a/styles/container-logs.less
+++ b/styles/container-logs.less
@@ -11,14 +11,25 @@
   }
 }
 
-.copy-logs__btn{
+.copy-logs__btn, .save-logs__btn{
+  float: left;
   border: 0;
 }
 
 .logs-font-size__select{
+  float: left;
   -webkit-border-radius: 0;
   outline: rgb(248, 248, 248) solid thick;
   outline-offset: -5px;
   height: 25px;
   margin-right: 4px;
+}
+
+.save-logs__btn{
+  height: 25px;
+  margin-right: 4px;
+}
+.save-logs__btn:hover{
+  -webkit-box-shadow: 0 0 2px 0 #FFF;
+  background-color: rgba(255, 255, 255, .3);
 }


### PR DESCRIPTION
**[NOW READY FOR REVIEW]**

- PR enables user to save container logs to file system

<img width="481" alt="screen shot 2017-12-14 at 15 20 04" src="https://user-images.githubusercontent.com/11579108/33992103-5e7cdf70-e0e2-11e7-90ca-1516d8337790.png">

**_[on save]_**

<img width="610" alt="screen shot 2017-12-14 at 15 34 49" src="https://user-images.githubusercontent.com/11579108/33992615-604e6ab0-e0e4-11e7-9fae-9a51393f5427.png">



Closes issue #2645 