### PR TITLE
[Feature] : Way to prevent auto-scroll down in "Container logs"

### DIFF
--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -40,17 +40,20 @@ let prevBottom = 0;
 module.exports = React.createClass({
   getInitialState: function(){
     return {
-      fontSize: 10
+      fontSize: 10,
+      follow: true,
     };
   },
   onFontChange: function(event){
-    this.setState({
-      fontSize: event.target.value
-    });
+    let $target = event.target;
+    this.setState((prevState)=>({
+      fontSize: $target.value,
+      follow: prevState.follow
+    }));
   },
   componentDidUpdate: function () {
     var node = $('.logs').get()[0];
-    node.scrollTop = node.scrollHeight;
+    node.scrollTop = (this.state.follow)? node.scrollHeight: 0;
   },
 
   componentWillReceiveProps: function (nextProps) {
@@ -65,6 +68,13 @@ module.exports = React.createClass({
 
   componentWillUnmount: function () {
     containerActions.active(null);
+  },
+  
+  toggleFollow: function () {
+    this.setState((prevState)=>({
+      fontSize: prevState.fontsize,
+      follow: !prevState.follow
+    }));
   },
 
   render: function () {
@@ -113,11 +123,15 @@ module.exports = React.createClass({
           <div className="top-bar">
             <div className="text">Container Logs</div>
             <div>
-                <button className="save-logs__btn" onClick={saveLogs}>
-                  <i className="icon icon-download"></i>
-                </button>
-                <FontSelect fontSize={this.state.fontSize} onChange={this.onFontChange} />
-                <button className="copy-logs__btn" onClick={copyLogs}>Copy</button>
+              <label className="follow-logs__label">
+                Follow&nbsp;
+                <input type="checkbox" onChange={ this.toggleFollow } checked={ this.state.follow }></input>
+              </label>
+              <button className="save-logs__btn" onClick={saveLogs}>
+                <i className="icon icon-download"></i>
+              </button>
+              <FontSelect fontSize={this.state.fontSize} onChange={this.onFontChange} />
+              <button className="copy-logs__btn" onClick={copyLogs}>Copy</button>
             </div>
           </div>
           <div className="logs" style={{fontSize:this.state.fontSize+'px'}}>

--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -53,7 +53,9 @@ module.exports = React.createClass({
   },
   componentDidUpdate: function () {
     var node = $('.logs').get()[0];
-    node.scrollTop = (this.state.follow)? node.scrollHeight: 0;
+    if(this.state.follow){
+      node.scrollTop = node.scrollHeight;
+    }
   },
 
   componentWillReceiveProps: function (nextProps) {

--- a/styles/container-logs.less
+++ b/styles/container-logs.less
@@ -11,12 +11,18 @@
   }
 }
 
-.copy-logs__btn, .save-logs__btn{
+.copy-logs__btn, .save-logs__btn {
   float: left;
   border: 0;
 }
 
-.logs-font-size__select{
+.follow-logs__label {
+  float: left;
+  margin: 3px 5px;
+  color: #eee;
+}
+
+.logs-font-size__select {
   float: left;
   -webkit-border-radius: 0;
   outline: rgb(248, 248, 248) solid thick;
@@ -25,11 +31,11 @@
   margin-right: 4px;
 }
 
-.save-logs__btn{
+.save-logs__btn {
   height: 25px;
   margin-right: 4px;
 }
-.save-logs__btn:hover{
+.save-logs__btn:hover {
   -webkit-box-shadow: 0 0 2px 0 #FFF;
   background-color: rgba(255, 255, 255, .3);
 }


### PR DESCRIPTION
PR enables the user to disable or enable following(auto-scroll down) for container logs. Enabled by default but can be disabled on user demand 🙂 .

_[screenshot]_
<img width="426" alt="screen shot 2018-01-03 at 11 12 42" src="https://user-images.githubusercontent.com/11579108/34513442-5a34c634-f079-11e7-991e-55625f7016cd.png">
 
Closes issue #2611 
  