### PR TITLE
- Fixed favorites containers initialize.

### DIFF
--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -45,7 +45,7 @@ class ContainerActions {
   }
 
   toggleFavorite (name) {
-    let favorites = JSON.parse(localStorage.getItem('containers.favorites'));
+    let favorites = JSON.parse(localStorage.getItem('containers.favorites')) || [];
     if (favorites.includes(name)) {
       favorites = favorites.filter(favoriteName => favoriteName !== name);
     } else {


### PR DESCRIPTION
Fix for the favorites containers feature.
Initialize the local history array with default an empty array.

Signed-off-by: Daniel Amram <danielamram0@gmail.com>