### PR TITLE
[Bug] Starting container (or tweaking settings) in Kitematic deletes `Labels` settings from `docker-compose`

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -185,6 +185,9 @@ var DockerUtil = {
         containerData.Cmd = 'sh';
       }
 
+      // Keep current config for new container if no changes
+      _.extend(containerData, _.omit(containerData.Config, Object.keys(containerData)));
+
       let existing = this.client.getContainer(name);
       existing.kill(() => {
         existing.remove(() => {


### PR DESCRIPTION
PR resolves issue #2849