### PR TITLE
Settings accessible on Ubuntu with long log lines

### DIFF
--- a/styles/container-home.less
+++ b/styles/container-home.less
@@ -10,6 +10,7 @@
       display: flex;
       flex: 0.9 1 0;
       flex-direction: column;
+      width: 60%;
       margin-right: 1rem;
     }
     .right {

--- a/styles/right-panel.less
+++ b/styles/right-panel.less
@@ -6,6 +6,7 @@
   flex: 1 0;
   display: flex;
   flex-direction: column;
+  width: 75%;
   .header-section {
     position: absolute;
     top: 10px;


### PR DESCRIPTION
Defining a width for the `.details` and the `.content .left` elements makes the home/settings tabs and the web preview next to the log lines visible and accessible even if there are very long lines in the request log.

Fixes: #3412 