### PR TITLE
ci: test Node.js 6, 8 and 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,15 @@ jobs:
     
     steps:
       - run:
-          name: Install node@9
+          name: Install node@10
           command: |
             set +e
             touch $BASH_ENV
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-            echo 'nvm install 9' >> $BASH_ENV
-            echo 'nvm alias default 9' >> $BASH_ENV
+            echo 'nvm install 10' >> $BASH_ENV
+            echo 'nvm alias default 10' >> $BASH_ENV
       - run:
           name: Install wine
           command: brew install wine

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 
 language: node_js
 node_js:
-    - "4.8.7"
+    - "6"
+    - "8"
+    - "10"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ cache:
 script:
   - npm install
   - npm test
+
+install: npm i


### PR DESCRIPTION
`Array.prototype.includes` is only available in Node.js 6.5+, see https://kangax.github.io/compat-table/es2016plus/#node6_5

https://travis-ci.org/docker/kitematic/builds/443616745