### PR TITLE
Add linux terminal emulator settings option

### DIFF
--- a/src/components/Preferences.react.js
+++ b/src/components/Preferences.react.js
@@ -13,6 +13,7 @@ var Preferences = React.createClass({
       useVM: localStorage.getItem('settings.useVM') === 'true',
       metricsEnabled: metrics.enabled(),
       terminalShell: localStorage.getItem('settings.terminalShell') || "sh",
+      terminalPath: localStorage.getItem('settings.terminalPath') || "/usr/bin/xterm",
       startLinkedContainers: localStorage.getItem('settings.startLinkedContainers') === 'true'
     };
   },
@@ -58,6 +59,13 @@ var Preferences = React.createClass({
     });
     localStorage.setItem('settings.terminalShell', value);
   },
+  handleChangeTerminalPath: function (e) {
+    var value = e.target.value;
+    this.setState({
+      terminalPath: value
+    });
+    localStorage.setItem('settings.terminalPath', value);
+  },
   handleChangeStartLinkedContainers: function (e) {
     var checked = e.target.checked;
     this.setState({
@@ -66,7 +74,7 @@ var Preferences = React.createClass({
     localStorage.setItem('settings.startLinkedContainers', checked ? 'true' : 'false');
   },
   render: function () {
-    var vmSettings, vmShutdown, nativeSetting;
+    var vmSettings, vmShutdown, nativeSetting, linuxSettings;
 
     if (process.platform !== 'linux') {
       // We are on a Mac or Windows
@@ -104,6 +112,21 @@ var Preferences = React.createClass({
       );
     }
 
+    if (process.platform === "linux") {
+      linuxSettings = (
+        <div>
+          <div className="option">
+            <div className="option-name">
+              <label htmlFor="terminalPath">Terminal path</label>
+            </div>
+            <div className="option-value">
+              <input id="terminalPath" type="text" value={this.state.terminalPath} onChange={this.handleChangeTerminalPath}/>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className="preferences">
         <div className="preferences-content">
@@ -137,6 +160,7 @@ var Preferences = React.createClass({
               <input id="startLinkedContainers" type="checkbox" checked={this.state.startLinkedContainers} onChange={this.handleChangeStartLinkedContainers}/>
             </div>
           </div>
+          {linuxSettings}
         </div>
       </div>
     );

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -201,13 +201,14 @@ module.exports = {
     return linuxAbsPath.replace('/c', 'C:').split('/').join('\\');
   },
   linuxTerminal: function () {
-    if (fs.existsSync('/usr/bin/x-terminal-emulator')) {
-      return ['/usr/bin/x-terminal-emulator', '-e'];
+    const terminalPath = localStorage.getItem('settings.terminalPath');
+    if (fs.existsSync(terminalPath)) {
+      return [terminalPath, '-e'];
     } else {
       dialog.showMessageBox({
         type: 'warning',
         buttons: ['OK'],
-        message: 'The symbolic link /usr/bin/x-terminal-emulator does not exist. Please read the Wiki at https://github.com/docker/kitematic/wiki/Early-Linux-Support for more information.'
+        message: `The ${terminalPath} does not exist please set the correct path.`
       });
       return false;
     }


### PR DESCRIPTION
I add a new field in the settings page, which can be used for set the terminal emulator path.
Now the /usr/bin/x-terminal-emulator is not necessary.