### PR TITLE
Display container name in its removal confirmation message

### DIFF
--- a/src/components/ContainerListItem.react.js
+++ b/src/components/ContainerListItem.react.js
@@ -18,7 +18,7 @@ var ContainerListItem = React.createClass({
     e.preventDefault();
     e.stopPropagation();
     dialog.showMessageBox({
-      message: 'Are you sure you want to stop & remove this container?',
+      message: `Are you sure you want to stop & remove the container '${this.props.container.Name}'?`,
       buttons: ['Remove', 'Cancel']
     }, function (index) {
       if (index === 0) {


### PR DESCRIPTION
This could avoid removing a container by accident when you misclick some of them

**Before**

<img width="633" alt="Delete container message without the container name" src="https://user-images.githubusercontent.com/3674112/52905483-d62b9200-3221-11e9-9e09-ed791ac67e36.png">

**After**

<img width="633" alt="Delete container message with the container name" src="https://user-images.githubusercontent.com/3674112/52905485-db88dc80-3221-11e9-8bb2-0dfaf4d0b1d8.png">
